### PR TITLE
Album 생성 UI 구현

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavGraph.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import cord.eoeo.momentwo.ui.album.AlbumRoute
+import cord.eoeo.momentwo.ui.createalbum.CreateAlbumRoute
 import cord.eoeo.momentwo.ui.login.LoginRoute
 import cord.eoeo.momentwo.ui.signup.SignUpRoute
 import kotlinx.coroutines.CoroutineScope
@@ -45,6 +46,15 @@ fun MomentwoNavGraph(
             route = MomentwoDestination.ALBUM_ROUTE,
         ) {
             AlbumRoute(
+                coroutineScope = coroutineScope,
+                navigateToCreateAlbum = navActions.navigateToCreateAlbum,
+            )
+        }
+
+        composable(
+            route = MomentwoDestination.CREATE_ALBUM_ROUTE,
+        ) {
+            CreateAlbumRoute(
                 coroutineScope = coroutineScope,
                 popBackStack = navActions.popBackStack,
             )

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
@@ -6,6 +6,7 @@ object MomentwoDestination {
     const val LOGIN_ROUTE = "login"
     const val SIGNUP_ROUTE = "signup"
     const val ALBUM_ROUTE = "album"
+    const val CREATE_ALBUM_ROUTE = "create_album"
 }
 
 class MomentwoNavigationActions(navController: NavHostController) {
@@ -15,13 +16,19 @@ class MomentwoNavigationActions(navController: NavHostController) {
     val navigateToLogin: () -> Unit = {
         navController.navigate(MomentwoDestination.LOGIN_ROUTE) {
             launchSingleTop = true
-            popUpTo(MomentwoDestination.LOGIN_ROUTE)
+            popUpTo(navController.graph.id)
         }
     }
     val navigateToSignUp: () -> Unit = {
         navController.navigate(MomentwoDestination.SIGNUP_ROUTE)
     }
     val navigateToAlbum: () -> Unit = {
-        navController.navigate(MomentwoDestination.ALBUM_ROUTE)
+        navController.navigate(MomentwoDestination.ALBUM_ROUTE) {
+            launchSingleTop = true
+            popUpTo(navController.graph.id)
+        }
+    }
+    val navigateToCreateAlbum: () -> Unit = {
+        navController.navigate(MomentwoDestination.CREATE_ALBUM_ROUTE)
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumContract.kt
@@ -12,13 +12,12 @@ class AlbumContract {
     ) : UiState
 
     sealed interface Event : UiEvent {
-        data class OnBack(val isDrawerOpen: Boolean) : Event
+        data object OnCloseDrawer : Event
         data class OnError(val errorMessage: String) : Event
     }
 
     sealed interface Effect : UiEffect {
         data object CloseDrawer : Effect
-        data object PopBackStack : Effect
         data class ShowSnackbar(val message: String) : Effect
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumRoute.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.launch
 @Composable
 fun AlbumRoute(
     coroutineScope: CoroutineScope,
-    popBackStack: () -> Unit,
+    navigateToCreateAlbum: () -> Unit,
     modifier: Modifier = Modifier,
     drawerState: DrawerState = rememberDrawerState(initialValue = DrawerValue.Closed),
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
@@ -33,6 +33,6 @@ fun AlbumRoute(
         snackbarHostState = { snackbarHostState },
         onClickDrawer = { coroutineScope.launch { drawerState.open() } },
         onCloseDrawer = { coroutineScope.launch { drawerState.close() } },
-        popBackStack = popBackStack,
+        navigateToCreateAlbum = navigateToCreateAlbum,
     )
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
@@ -50,7 +50,7 @@ fun AlbunScreen(
     snackbarHostState: () -> SnackbarHostState,
     onClickDrawer: () -> Unit,
     onCloseDrawer: () -> Unit,
-    popBackStack: () -> Unit,
+    navigateToCreateAlbum: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     LaunchedEffect(SIDE_EFFECTS_KEY) {
@@ -58,10 +58,6 @@ fun AlbunScreen(
             when (effect) {
                 is AlbumContract.Effect.CloseDrawer -> {
                     onCloseDrawer()
-                }
-
-                is AlbumContract.Effect.PopBackStack -> {
-                    popBackStack()
                 }
 
                 is AlbumContract.Effect.ShowSnackbar -> {
@@ -73,8 +69,8 @@ fun AlbunScreen(
         }.collect()
     }
 
-    BackHandler {
-        onEvent(AlbumContract.Event.OnBack(drawerState().isOpen))
+    BackHandler(drawerState().isOpen) {
+        onEvent(AlbumContract.Event.OnCloseDrawer)
     }
 
     // 테스트용 가짜 앨범 아이템 리스트
@@ -103,7 +99,7 @@ fun AlbunScreen(
                     onClickSearch = { /*TODO: Navigate to Search*/ },
                 )
             },
-            floatingActionButton = { CreateAlbumFAB { /*TODO: Navigate to Create Album*/ } },
+            floatingActionButton = { CreateAlbumFAB(onClick = navigateToCreateAlbum) },
             snackbarHost = { SnackbarHost(hostState = snackbarHostState()) },
             modifier = Modifier.fillMaxSize(),
         ) { paddingValues ->

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumViewModel.kt
@@ -12,12 +12,8 @@ class AlbumViewModel @Inject constructor(
 
     override fun handleEvent(newEvent: AlbumContract.Event) {
         when (newEvent) {
-            is AlbumContract.Event.OnBack -> {
-                if (newEvent.isDrawerOpen) {
-                    setEffect { AlbumContract.Effect.CloseDrawer }
-                } else {
-                    setEffect { AlbumContract.Effect.PopBackStack }
-                }
+            is AlbumContract.Event.OnCloseDrawer -> {
+                setEffect { AlbumContract.Effect.CloseDrawer }
             }
 
             is AlbumContract.Event.OnError -> {

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/InviteDialog.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/InviteDialog.kt
@@ -1,0 +1,139 @@
+package cord.eoeo.momentwo.ui.composable
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Card
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import cord.eoeo.momentwo.ui.model.UserItem
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@Composable
+fun InviteDialog(
+    onDismissRequest: () -> Unit
+) {
+    val fakeFriendItems = listOf(
+        UserItem(1, "User1"),
+        UserItem(2, "User22"),
+        UserItem(3, "User333"),
+        UserItem(4, "User4"),
+        UserItem(5, "User55"),
+        UserItem(6, "User6666"),
+        UserItem(7, "User77"),
+        UserItem(8, "User8"),
+        UserItem(9, "User9999"),
+        UserItem(10, "User10"),
+        UserItem(11, "User1111"),
+        UserItem(12, "User12"),
+    )
+
+    var str: String by remember { mutableStateOf("") }
+
+    Dialog(
+        onDismissRequest = onDismissRequest,
+        properties = DialogProperties(
+            usePlatformDefaultWidth = false,
+        ),
+    ) {
+        Card(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 48.dp),
+            shape = RoundedCornerShape(16.dp),
+        ) {
+            SearchBar(
+                query = str,
+                onQueryChange = { str = it },
+                onSearch = {},
+                active = true,
+                onActiveChange = {},
+                placeholder = { Text(text = "친구 검색") },
+                leadingIcon = {
+                    IconButton(onClick = onDismissRequest) {
+                        Icon(Icons.AutoMirrored.Default.ArrowBack, "")
+                    }
+                },
+                trailingIcon = {
+                    IconButton(onClick = { /*TODO: Search*/ }) {
+                        Icon(Icons.Default.Search, "")
+                    }
+                },
+            ) {
+                LazyRow(
+                    modifier = Modifier
+                        .height(80.dp)
+                        .fillMaxWidth(),
+                ) {
+                    items(items = fakeFriendItems, key = { it.id }) { userItem ->
+                        UserItemBox(
+                            userItem = { userItem },
+                            onClickClear = { /*TODO*/ },
+                            modifier = Modifier
+                                .animateItemPlacement()
+                                .fillMaxHeight(),
+                        )
+                    }
+                }
+
+                HorizontalDivider()
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
+                ) {
+                    items(items = fakeFriendItems, key = { it.id }) { userItem ->
+                        ListItem(
+                            leadingContent = { Icon(Icons.Default.AccountCircle, "") },
+                            headlineContent = { Text(text = userItem.nickname) },
+                            trailingContent = { Checkbox(checked = true, onCheckedChange = { /**/ }) },
+                        )
+                    }
+                }
+
+                HorizontalDivider()
+
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
+                ) {
+                    TextButton(onClick = { /*TODO: Confirm Invite Dialog*/ }) {
+                        Text(text = "완료")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/UserItemBox.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/UserItemBox.kt
@@ -1,0 +1,72 @@
+package cord.eoeo.momentwo.ui.composable
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cord.eoeo.momentwo.ui.model.UserItem
+
+@Composable
+fun UserItemBox(
+    userItem: () -> UserItem,
+    onClickClear: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .aspectRatio(1f)
+            .padding(8.dp),
+    ) {
+        IconButton(
+            onClick = onClickClear,
+            modifier = Modifier
+                .size(18.dp)
+                .align(Alignment.TopEnd),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Clear,
+                contentDescription = "",
+                tint = Color.Gray,
+            )
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxSize(),
+        ) {
+            Icon(
+                imageVector = Icons.Default.AccountCircle,
+                contentDescription = "",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+            )
+            Text(
+                text = userItem().nickname,
+                fontSize = 13.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 4.dp),
+            )
+        }
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumContract.kt
@@ -1,0 +1,26 @@
+package cord.eoeo.momentwo.ui.createalbum
+
+import cord.eoeo.momentwo.ui.UiEffect
+import cord.eoeo.momentwo.ui.UiEvent
+import cord.eoeo.momentwo.ui.UiState
+
+class CreateAlbumContract {
+    data class State(
+        val isInviteFriendOpened: Boolean = false,
+        val isLoading: Boolean = false,
+        val isSuccess: Boolean = false,
+        val isError: Boolean = false,
+    ) : UiState
+
+    sealed interface Event : UiEvent {
+        data object OnClickInviteFriend : Event
+        data object OnDismissInviteFriend : Event
+        data object OnBack : Event
+        data class OnError(val errorMessage: String) : Event
+    }
+
+    sealed interface Effect : UiEffect {
+        data object PopBackStack : Effect
+        data class ShowSnackbar(val message: String) : Effect
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumRoute.kt
@@ -1,0 +1,30 @@
+package cord.eoeo.momentwo.ui.createalbum
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+fun CreateAlbumRoute(
+    coroutineScope: CoroutineScope,
+    popBackStack: () -> Unit,
+    modifier: Modifier = Modifier,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    viewModel: CreateAlbumViewModel = hiltViewModel(),
+) {
+    val uiState: CreateAlbumContract.State by viewModel.uiState.collectAsStateWithLifecycle()
+
+    CreateAlbumScreen(
+        coroutineScope = coroutineScope,
+        uiState = { uiState },
+        effectFlow = { viewModel.effect },
+        onEvent = { event -> viewModel.setEvent(event) },
+        snackbarHostState = { snackbarHostState },
+        popBackStack = popBackStack,
+    )
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
@@ -1,0 +1,207 @@
+package cord.eoeo.momentwo.ui.createalbum
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.ElevatedButton
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.ui.composable.InviteDialog
+import cord.eoeo.momentwo.ui.composable.UserItemBox
+import cord.eoeo.momentwo.ui.model.UserItem
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun CreateAlbumScreen(
+    coroutineScope: CoroutineScope,
+    uiState: () -> CreateAlbumContract.State,
+    effectFlow: () -> Flow<CreateAlbumContract.Effect>,
+    onEvent: (event: CreateAlbumContract.Event) -> Unit,
+    snackbarHostState: () -> SnackbarHostState,
+    popBackStack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LaunchedEffect(SIDE_EFFECTS_KEY) {
+        effectFlow().onEach { effect ->
+            when (effect) {
+                is CreateAlbumContract.Effect.PopBackStack -> {
+                    popBackStack()
+                }
+
+                is CreateAlbumContract.Effect.ShowSnackbar -> {
+                    snackbarHostState().showSnackbar(
+                        message = effect.message,
+                    )
+                }
+            }
+        }.collect()
+    }
+
+    if (uiState().isInviteFriendOpened) {
+        InviteDialog {
+            onEvent(CreateAlbumContract.Event.OnDismissInviteFriend)
+        }
+    }
+
+    val fakeUserItems = listOf(
+        UserItem(1, "User1"),
+        UserItem(2, "User22"),
+        UserItem(3, "User333"),
+        UserItem(4, "User44444444"),
+        UserItem(5, "User5555"),
+        UserItem(6, "User66"),
+    )
+
+    Scaffold(
+        topBar = { CreateAlbumTopAppBar(onClickNavigation = { onEvent(CreateAlbumContract.Event.OnBack) }) },
+        modifier = Modifier.fillMaxSize(),
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .padding(top = 8.dp)
+                .padding(horizontal = 24.dp),
+        ) {
+            TitleText(text = { "앨범명" })
+            CaptionText(text = { "앨범을 나타낼 수 있는 이름을 지어주세요" })
+            OutlinedTextField(
+                value = "",
+                onValueChange = { /*TODO*/ },
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Row {
+                Column(
+                    modifier = Modifier
+                        .weight(1f),
+                ) {
+                    TitleText(text = { "친구 초대" })
+                    CaptionText(text = { "앨범을 같이 사용할 친구를 초대하세요" })
+                }
+                ElevatedButton(
+                    onClick = { onEvent(CreateAlbumContract.Event.OnClickInviteFriend) },
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically),
+                ) {
+                    Icon(Icons.Default.Add, "")
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Text(text = "추가")
+                }
+            }
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(80.dp),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 8.dp)
+                    .weight(1f),
+            ) {
+                items(items = fakeUserItems, key = { it.id }) { userItem ->
+                    UserItemBox(
+                        userItem = { userItem },
+                        onClickClear = { /*TODO*/ },
+                        modifier = Modifier
+                            .animateItemPlacement()
+                            .fillMaxWidth(),
+                    )
+                }
+            }
+
+            ConfirmExtendedFAB(
+                onClick = { /*TODO: Create Album & Navigate to Album*/ },
+                modifier = Modifier
+                    .align(Alignment.End)
+                    .padding(vertical = 16.dp),
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateAlbumTopAppBar(
+    onClickNavigation: () -> Unit
+) {
+    TopAppBar(
+        title = {
+            Text(
+                text = "Create Album",
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        navigationIcon = {
+            IconButton(onClick = onClickNavigation) {
+                Icon(Icons.AutoMirrored.Filled.ArrowBack, "")
+            }
+        },
+    )
+}
+
+@Composable
+fun TitleText(text: () -> String) {
+    Text(
+        text = text(),
+        fontWeight = FontWeight.Bold,
+        fontSize = 24.sp,
+        maxLines = 1,
+    )
+}
+
+@Composable
+fun CaptionText(text: () -> String) {
+    Text(
+        text = text(),
+        fontWeight = FontWeight.Light,
+        fontSize = 15.sp,
+        maxLines = 1,
+        modifier = Modifier.padding(bottom = 4.dp),
+    )
+}
+
+@Composable
+fun ConfirmExtendedFAB(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ExtendedFloatingActionButton(
+        text = { Text(text = "완료") },
+        icon = { Icon(Icons.Default.Check, "") },
+        onClick = onClick,
+        elevation = FloatingActionButtonDefaults.loweredElevation(),
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumViewModel.kt
@@ -1,0 +1,32 @@
+package cord.eoeo.momentwo.ui.createalbum
+
+import cord.eoeo.momentwo.ui.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class CreateAlbumViewModel @Inject constructor(
+
+) : BaseViewModel<CreateAlbumContract.State, CreateAlbumContract.Event, CreateAlbumContract.Effect>() {
+    override fun createInitialState(): CreateAlbumContract.State = CreateAlbumContract.State()
+
+    override fun handleEvent(newEvent: CreateAlbumContract.Event) {
+        when (newEvent) {
+            is CreateAlbumContract.Event.OnClickInviteFriend -> {
+                setState(uiState.value.copy(isInviteFriendOpened = true))
+            }
+
+            is CreateAlbumContract.Event.OnDismissInviteFriend -> {
+                setState(uiState.value.copy(isInviteFriendOpened = false))
+            }
+
+            is CreateAlbumContract.Event.OnBack -> {
+                setEffect { CreateAlbumContract.Effect.PopBackStack }
+            }
+
+            is CreateAlbumContract.Event.OnError -> {
+                setEffect { CreateAlbumContract.Effect.ShowSnackbar(newEvent.errorMessage) }
+            }
+        }
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/model/UserItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/model/UserItem.kt
@@ -1,0 +1,6 @@
+package cord.eoeo.momentwo.ui.model
+
+data class UserItem(
+    val id: Int,
+    val nickname: String,
+)


### PR DESCRIPTION
## PR 내용
### Album 화면 Back Stack 정리 수정
- Album으로 Navigation 시 Back Stack에서 Login 화면이 정리되지 않는 문제 수정

### Album 생성 UI 구현
- CreateAlbumScreen 구현
    - 앨범명 TextField
    - 친구 초대 Button
    - 초대한 친구 목록을 보여줄 LazyVerticalGrid 구현
- CreateAlbumRoute 구현
- Navigation 연결

### Member 초대 Dialog 구현
- InviteDialog 구현
    - 검색 가능한 TopBar 구현
    - 초대할 친구 목록을 보여줄 LazyRow 구현
    - 검색 결과 목록을 보여줄 LazyColumn 구현

Fix: #24 
Resolve: #22 
Resolve: #23 