### PR TITLE
Dispatcher 누락 수정, Album content-type 누락 수정, 파라미터 수정

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumDataSource.kt
@@ -2,7 +2,6 @@ package cord.eoeo.momentwo.data.album
 
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
-import cord.eoeo.momentwo.data.model.AlbumTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 
 interface AlbumDataSource {
@@ -20,6 +19,6 @@ interface AlbumDataSource {
 
     suspend fun changeAlbumTitle(
         albumId: Int,
-        albumTitle: AlbumTitle,
+        editTitle: String,
     ): Result<Unit>
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumRepositoryImpl.kt
@@ -2,7 +2,6 @@ package cord.eoeo.momentwo.data.album
 
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
-import cord.eoeo.momentwo.data.model.AlbumTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import cord.eoeo.momentwo.domain.album.AlbumRepository
 import okhttp3.MultipartBody
@@ -13,40 +12,26 @@ class AlbumRepositoryImpl(
     override suspend fun requestCreateAlbum(
         title: String,
         inviteList: List<String>,
-    ): Result<Unit> {
-        return albumRemoteDataSource.requestCreateAlbum(CreateAlbumInfo(title, inviteList))
-    }
+    ): Result<Unit> = albumRemoteDataSource.requestCreateAlbum(CreateAlbumInfo(title, inviteList))
 
-    override suspend fun deleteAlbum(albumId: Int): Result<Unit> {
-        return albumRemoteDataSource.deleteAlbum(albumId)
-    }
+    override suspend fun deleteAlbum(albumId: Int): Result<Unit> = albumRemoteDataSource.deleteAlbum(albumId)
 
     override suspend fun changeAlbumImage(
         albumId: String,
         profileImage: MultipartBody.Part,
-    ): Result<Unit> {
-        return albumRemoteDataSource.changeAlbumImage(AlbumImage(albumId, profileImage))
-    }
+    ): Result<Unit> = albumRemoteDataSource.changeAlbumImage(AlbumImage(albumId, profileImage))
 
-    override suspend fun deleteAlbumImage(albumId: Int): Result<Unit> {
-        return albumRemoteDataSource.deleteAlbumImage(albumId)
-    }
+    override suspend fun deleteAlbumImage(albumId: Int): Result<Unit> = albumRemoteDataSource.deleteAlbumImage(albumId)
 
     override suspend fun changeAlbumSubTitle(
         albumId: Int,
         subTitle: String,
-    ): Result<Unit> {
-        return albumRemoteDataSource.changeAlbumSubTitle(AlbumSubTitle(albumId, subTitle))
-    }
+    ): Result<Unit> = albumRemoteDataSource.changeAlbumSubTitle(AlbumSubTitle(albumId, subTitle))
 
-    override suspend fun deleteAlbumSubTitle(albumId: Int): Result<Unit> {
-        return albumRemoteDataSource.deleteAlbumSubTitle(albumId)
-    }
+    override suspend fun deleteAlbumSubTitle(albumId: Int): Result<Unit> = albumRemoteDataSource.deleteAlbumSubTitle(albumId)
 
     override suspend fun changeAlbumTitle(
         albumId: Int,
         title: String,
-    ): Result<Unit> {
-        return albumRemoteDataSource.changeAlbumTitle(albumId, AlbumTitle(title))
-    }
+    ): Result<Unit> = albumRemoteDataSource.changeAlbumTitle(albumId, title)
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumRemoteDataSource.kt
@@ -3,7 +3,6 @@ package cord.eoeo.momentwo.data.album.remote
 import cord.eoeo.momentwo.data.album.AlbumDataSource
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
-import cord.eoeo.momentwo.data.model.AlbumTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -57,11 +56,11 @@ class AlbumRemoteDataSource(
 
     override suspend fun changeAlbumTitle(
         albumId: Int,
-        albumTitle: AlbumTitle,
+        editTitle: String,
     ): Result<Unit> =
         runCatching {
             withContext(dispatcher) {
-                albumService.putAlbumTitle(albumId, albumTitle)
+                albumService.putAlbumTitle(albumId, editTitle)
             }
         }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
@@ -3,10 +3,10 @@ package cord.eoeo.momentwo.data.album.remote
 import cord.eoeo.momentwo.data.MomentwoApi
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
-import cord.eoeo.momentwo.data.model.AlbumTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.Headers
 import retrofit2.http.Multipart
 import retrofit2.http.POST
@@ -26,6 +26,7 @@ interface AlbumService {
     )
 
     @Multipart
+    @Headers("content-type: application/json")
     @PUT(MomentwoApi.PUT_ALBUM_IMAGE)
     suspend fun putAlbumImage(
         @Body albumImage: AlbumImage,
@@ -36,6 +37,7 @@ interface AlbumService {
         @Path("albumId") albumId: Int,
     )
 
+    @Headers("content-type: application/json")
     @PUT(MomentwoApi.PUT_ALBUM_SUBTITLE)
     suspend fun putAlbumSubTitle(
         @Body albumSubTitle: AlbumSubTitle,
@@ -46,9 +48,10 @@ interface AlbumService {
         @Path("albumId") albumId: Int,
     )
 
+    @FormUrlEncoded
     @PUT(MomentwoApi.PUT_ALBUM_TITLE)
     suspend fun putAlbumTitle(
         @Path("id") albumId: Int,
-        @Body albumTitle: AlbumTitle,
+        @Body editTitle: String,
     )
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
@@ -24,8 +24,3 @@ data class AlbumSubTitle(
     val albumId: Int,
     val subTitle: String,
 )
-
-@JsonClass(generateAdapter = true)
-data class AlbumTitle(
-    val title: String,
-)

--- a/app/src/main/java/cord/eoeo/momentwo/data/subalbum/remote/SubAlbumRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/subalbum/remote/SubAlbumRemoteDataSource.kt
@@ -5,27 +5,39 @@ import cord.eoeo.momentwo.data.model.EditSubAlbumInfo
 import cord.eoeo.momentwo.data.model.SubAlbumIds
 import cord.eoeo.momentwo.data.model.SubAlbumList
 import cord.eoeo.momentwo.data.subalbum.SubAlbumDataSource
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 class SubAlbumRemoteDataSource(
     private val subAlbumService: SubAlbumService,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : SubAlbumDataSource {
     override suspend fun requestCreateSubAlbum(createSubAlbumInfo: CreateSubAlbumInfo): Result<Unit> =
         runCatching {
-            subAlbumService.postCreateSubAlbum(createSubAlbumInfo)
+            withContext(dispatcher) {
+                subAlbumService.postCreateSubAlbum(createSubAlbumInfo)
+            }
         }
 
     override suspend fun getSubAlbumList(albumId: Int): Result<SubAlbumList> =
         runCatching {
-            subAlbumService.getSubAlbumList(albumId)
+            withContext(dispatcher) {
+                subAlbumService.getSubAlbumList(albumId)
+            }
         }
 
     override suspend fun changeSubAlbumTitle(editSubAlbumInfo: EditSubAlbumInfo): Result<Unit> =
         runCatching {
-            subAlbumService.putEditSubAlbum(editSubAlbumInfo)
+            withContext(dispatcher) {
+                subAlbumService.putEditSubAlbum(editSubAlbumInfo)
+            }
         }
 
     override suspend fun deleteSubAlbums(subAlbumIds: SubAlbumIds): Result<Unit> =
         runCatching {
-            subAlbumService.deleteSubAlbums(subAlbumIds)
+            withContext(dispatcher) {
+                subAlbumService.deleteSubAlbums(subAlbumIds)
+            }
         }
 }


### PR DESCRIPTION
## SubAlbumRemoteDataSource Dispatcher 적용
- runCatching 내부 withContext 사용 (Dispatchers.IO)

## AlbumService 수정
- content-type Json 누락 수정
- Album - editTitle 파라미터 수정
    - Content Type Json -> FormUrlencoded
    - 파라미터명 title -> editTitle

Resolve: #48
Resolve: #50  