### PR TITLE
Update Gradle & Libraries Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # BlueJ files
 *.ctxt
 
+# Build
+.kotlin/
+
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,10 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.kotlinAndroid)
+    alias(libs.plugins.composeCompiler)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlinSerialization)
 }
 
 android {
@@ -29,24 +30,25 @@ android {
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }
+    
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
+
     buildFeatures {
         compose = true
     }
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.1"
-    }
+
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+}
+
+kotlin {
+    jvmToolchain(17)
 }
 
 dependencies {
@@ -93,6 +95,9 @@ dependencies {
 
     // DataStore
     implementation(libs.datastore)
+
+    // Kotlin Serialization
+    implementation(libs.kotlin.serialization)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestScreen.kt
@@ -62,7 +62,7 @@ fun FriendRequestScreen(
 
         HorizontalPager(
             state = pagerState(),
-            beyondBoundsPageCount = 1,
+            beyondViewportPageCount = 1,
             modifier =
                 Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpScreen.kt
@@ -91,7 +91,7 @@ fun SignUpScreen(
             state = pagerState(),
             userScrollEnabled = false,
             modifier = Modifier.fillMaxWidth(),
-            beyondBoundsPageCount = 1,
+            beyondViewportPageCount = 1,
         ) { page ->
             if (page == 0) {
                 FirstSignUpPage(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.androidApplication) apply false
     alias(libs.plugins.kotlinAndroid) apply false
+    alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlinSerialization) apply false
 }
 true // Needed to make the Suppress annotation work for the plugins block

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,23 +1,24 @@
 [versions]
-agp = "8.2.2"
-kotlin = "1.9.0"
+agp = "8.5.2"
+kotlin = "2.0.20"
 core-ktx = "1.13.1"
-ksp = "1.9.0-1.0.13"
+ksp = "2.0.20-1.0.25"
 junit = "4.13.2"
-androidx-test-ext-junit = "1.1.5"
-espresso-core = "3.5.1"
-lifecycle = "2.7.0"
-activity-compose = "1.9.0"
-compose-bom = "2024.05.00"
-compose-version = "1.6.7"
-navigation-compose = "2.7.7"
+androidx-test-ext-junit = "1.2.1"
+espresso-core = "3.6.1"
+lifecycle = "2.8.6"
+activity-compose = "1.9.2"
+compose-bom = "2024.09.02"
+compose-version = "1.7.2"
+navigation-compose = "2.8.1"
 hilt-compose = "1.2.0"
-hilt = "2.51.1"
+hilt = "2.52"
 retrofit = "2.11.0"
 moshi = "1.15.1"
 coil = "2.7.0"
 datastore = "1.1.1"
 okhttp-bom = "4.12.0"
+kotlin-serialization = "1.7.3"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -44,6 +45,7 @@ coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil" }
 datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp-bom" }
+kotlin-serialization = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlin-serialization" }
 ui = { group = "androidx.compose.ui", name = "ui" }
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
@@ -58,4 +60,6 @@ okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-i
 androidApplication = { id = "com.android.application", version.ref = "agp" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
+composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Apr 12 02:13:27 KST 2024
+#Sat Sep 21 00:34:06 KST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## PR 내용
### Update Gradle & Libraries Version
- agp 8.5.2 (edit)
- gradle 8.7
- kotlin 2.0.20 : .gitignore 추가
- compose-bom 2024.09.02
- lifecycle 2.8.6
- HorizontalPager 파라미터명 변경 대응 (beyondBoundsPageCount -> beyondViewportPageCount)

Resolve: #54 