### PR TITLE
AlbumDetail 화면 수정 & 기능 연결

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
@@ -24,6 +24,8 @@ object MomentwoApi {
     /** Require @Path("id") */
     const val PUT_ALBUM_TITLE = "/albums/edit/{id}"
     const val GET_ALBUM_LIST = "/albums"
+    /** Require @Path("albumId") */
+    const val GET_ALBUM_ROLE = "/albums/rules/{albumId}"
 
     // SubAlbum
     const val POST_CREATE_SUBALBUM = "/album/sub/create"

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumDataSource.kt
@@ -2,6 +2,7 @@ package cord.eoeo.momentwo.data.album
 
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumInfoList
+import cord.eoeo.momentwo.data.model.AlbumRole
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 
@@ -24,4 +25,6 @@ interface AlbumDataSource {
     ): Result<Unit>
 
     suspend fun getAlbumList(): Result<AlbumInfoList>
+
+    suspend fun getAlbumRole(albumId: Int): Result<AlbumRole>
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package cord.eoeo.momentwo.data.album
 
-import cord.eoeo.momentwo.data.model.AlbumImage
+import android.net.Uri
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import cord.eoeo.momentwo.domain.album.AlbumRepository
 import cord.eoeo.momentwo.ui.model.AlbumItem
-import okhttp3.MultipartBody
+import cord.eoeo.momentwo.ui.model.MemberAuth
 
 class AlbumRepositoryImpl(
     private val albumRemoteDataSource: AlbumDataSource,
@@ -18,9 +18,13 @@ class AlbumRepositoryImpl(
     override suspend fun deleteAlbum(albumId: Int): Result<Unit> = albumRemoteDataSource.deleteAlbum(albumId)
 
     override suspend fun changeAlbumImage(
-        albumId: String,
-        profileImage: MultipartBody.Part,
-    ): Result<Unit> = albumRemoteDataSource.changeAlbumImage(AlbumImage(albumId, profileImage))
+        albumId: Int,
+        profileImage: Uri,
+    ): Result<Unit> {
+        // TODO Uri to MultipartBody.Part
+        return Result.success(Unit)
+        // return albumRemoteDataSource.changeAlbumImage(AlbumImage(albumId, profileImage))
+    }
 
     override suspend fun deleteAlbumImage(albumId: Int): Result<Unit> = albumRemoteDataSource.deleteAlbumImage(albumId)
 
@@ -29,7 +33,8 @@ class AlbumRepositoryImpl(
         subTitle: String,
     ): Result<Unit> = albumRemoteDataSource.changeAlbumSubTitle(AlbumSubTitle(albumId, subTitle))
 
-    override suspend fun deleteAlbumSubTitle(albumId: Int): Result<Unit> = albumRemoteDataSource.deleteAlbumSubTitle(albumId)
+    override suspend fun deleteAlbumSubTitle(albumId: Int): Result<Unit> =
+        albumRemoteDataSource.deleteAlbumSubTitle(albumId)
 
     override suspend fun changeAlbumTitle(
         albumId: Int,
@@ -39,5 +44,32 @@ class AlbumRepositoryImpl(
     override suspend fun getAlbumList(): Result<List<AlbumItem>> =
         albumRemoteDataSource.getAlbumList().map { albumItemList ->
             albumItemList.albumList.map { it.mapToAlbumItem() }
+        }
+    /*Result.success(
+        listOf(
+            AlbumItem(
+                id = 0,
+                title = "album1",
+                subTitle = "sub1",
+                imageUrl = "https://images.unsplash.com/photo-1717652480757-555af691acbb?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+            ),
+            AlbumItem(
+                id = 1,
+                title = "album2",
+                subTitle = "sub2",
+                imageUrl = "https://images.unsplash.com/photo-1717652480757-555af691acbb?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+            ),
+            AlbumItem(
+                id = 2,
+                title = "album3",
+                subTitle = "sub3",
+                imageUrl = "https://images.unsplash.com/photo-1717652480757-555af691acbb?q=80&w=1587&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+            ),
+        )
+    )*/
+
+    override suspend fun getAlbumRole(albumId: Int): Result<MemberAuth> =
+        albumRemoteDataSource.getAlbumRole(albumId).map { albumRole ->
+            albumRole.rules.mapToMemberAuth()
         }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumRemoteDataSource.kt
@@ -3,6 +3,7 @@ package cord.eoeo.momentwo.data.album.remote
 import cord.eoeo.momentwo.data.album.AlbumDataSource
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumInfoList
+import cord.eoeo.momentwo.data.model.AlbumRole
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import kotlinx.coroutines.CoroutineDispatcher
@@ -69,6 +70,13 @@ class AlbumRemoteDataSource(
         runCatching {
             withContext(dispatcher) {
                 albumService.getAlbumList()
+            }
+        }
+
+    override suspend fun getAlbumRole(albumId: Int): Result<AlbumRole> =
+        runCatching {
+            withContext(dispatcher) {
+                albumService.getAlbumRole(albumId)
             }
         }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
@@ -3,6 +3,7 @@ package cord.eoeo.momentwo.data.album.remote
 import cord.eoeo.momentwo.data.MomentwoApi
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumInfoList
+import cord.eoeo.momentwo.data.model.AlbumRole
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import retrofit2.http.Body
@@ -59,4 +60,9 @@ interface AlbumService {
 
     @GET(MomentwoApi.GET_ALBUM_LIST)
     suspend fun getAlbumList(): AlbumInfoList
+
+    @GET(MomentwoApi.GET_ALBUM_ROLE)
+    suspend fun getAlbumRole(
+        @Path("albumId") albumId: Int,
+    ): AlbumRole
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
@@ -16,7 +16,7 @@ data class CreateAlbumInfo(
 
 @JsonClass(generateAdapter = true)
 data class AlbumImage(
-    val albumId: String,
+    val albumId: Int,
     @Part val profileImage: MultipartBody.Part,
 )
 
@@ -46,4 +46,10 @@ data class AlbumInfo(
 data class AlbumInfoList(
     @Json(name = "album")
     val albumList: List<AlbumInfo>,
+)
+
+@JsonClass(generateAdapter = true)
+data class AlbumRole(
+    val albumId: Int,
+    val rules: MemberRule,
 )

--- a/app/src/main/java/cord/eoeo/momentwo/domain/album/AlbumRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/album/AlbumRepository.kt
@@ -1,7 +1,8 @@
 package cord.eoeo.momentwo.domain.album
 
+import android.net.Uri
 import cord.eoeo.momentwo.ui.model.AlbumItem
-import okhttp3.MultipartBody
+import cord.eoeo.momentwo.ui.model.MemberAuth
 
 interface AlbumRepository {
     suspend fun requestCreateAlbum(
@@ -12,8 +13,8 @@ interface AlbumRepository {
     suspend fun deleteAlbum(albumId: Int): Result<Unit>
 
     suspend fun changeAlbumImage(
-        albumId: String,
-        profileImage: MultipartBody.Part,
+        albumId: Int,
+        profileImage: Uri,
     ): Result<Unit>
 
     suspend fun deleteAlbumImage(albumId: Int): Result<Unit>
@@ -31,4 +32,6 @@ interface AlbumRepository {
     ): Result<Unit>
 
     suspend fun getAlbumList(): Result<List<AlbumItem>>
+
+    suspend fun getAlbumRole(albumId: Int): Result<MemberAuth>
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailContract.kt
@@ -1,14 +1,30 @@
 package cord.eoeo.momentwo.ui.albumdetail
 
+import android.net.Uri
 import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
 import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.ui.model.MemberAuth
+import cord.eoeo.momentwo.ui.model.MemberItem
+import cord.eoeo.momentwo.ui.model.SubAlbumItem
 
 class AlbumDetailContract {
     data class State(
         val albumItem: AlbumItem = AlbumItem(-1, "", "", ""),
         val selectedNavIndex: Int = 0,
+        val permission: MemberAuth = MemberAuth.ADMIN,
+        val subAlbumList: List<SubAlbumItem> = emptyList(),
+        val selectedSubAlbumIds: List<Int> = emptyList(),
+        val memberList: List<MemberItem> = emptyList(),
+        val selectedMemberNicknames: List<String> = emptyList(),
+        val friendList: List<FriendItem> = emptyList(),
+        val selectedFriendList: List<FriendItem> = emptyList(),
+        val textFieldDialogIndex: Int = -1,
+        val isInviteDialogOpened: Boolean = false,
+        val isEditMode: Boolean = false,
+        val isInChangeImage: Boolean = false,
         val isLoading: Boolean = false,
         val isSuccess: Boolean = false,
         val isError: Boolean = false,
@@ -16,12 +32,56 @@ class AlbumDetailContract {
 
     sealed interface Event : UiEvent {
         data class OnChangeNavIndex(val index: Int) : Event
+        data object OnGetFriendList : Event
+        data object OnGetPermission : Event
+        data class OnChangeFriendSelected(val isSelected: Boolean, val friendItem: FriendItem) : Event
+        data class OnChangeSubAlbumSelected(val isSelected: Boolean, val subAlbumId: Int) : Event
+        data class OnChangeMemberSelected(val isSelected: Boolean, val memberNickname: String) : Event
+        data object OnClickAdd : Event
+        data object OnClickEdit : Event
+        data object OnCancelEdit : Event
+        data object OnConfirmEdit : Event
+        data class OnOpenTextFieldDialog(val index: Int) : Event
+        data object OnDismissTextFieldDialog : Event
+        data object OnClickInvite : Event
+        data object OnDismissInviteFriend : Event
+        data object OnConfirmInviteFriend : Event
+        data class OnChangeIsInChangeImage(val isInChangeImage: Boolean) : Event
+        data class OnSubAlbumEvents(val subAlbumEvents: SubAlbumEvents) : Event
+        data class OnMemberEvents(val memberEvents: MemberEvents) : Event
+        data class OnAlbumSettingEvents(val albumSettingEvents: AlbumSettingEvents) : Event
         data object OnBack : Event
+        data object OnBackInAlbumDetail : Event
         data class OnError(val errorMessage: String) : Event
     }
 
     sealed interface Effect : UiEffect {
         data object PopBackStack : Effect
+        data object PopBackStackInAlbumDetail : Effect
         data class ShowSnackbar(val message: String) : Effect
+    }
+
+    sealed interface SubAlbumEvents {
+        data class Create(val subAlbumTitle: String) : SubAlbumEvents
+        data object GetSubAlbums : SubAlbumEvents
+        data class EditTitle(val subAlbumId: Int, val title: String) : SubAlbumEvents
+        data class DeleteSubAlbums(val subAlbumIds: List<Int>) : SubAlbumEvents
+    }
+
+    sealed interface MemberEvents {
+        data object Exit : MemberEvents
+        data object GetMembers : MemberEvents
+        data class KickMembers(val kickMembers: List<String>) : MemberEvents
+        data class AssignAdmin(val nickname: String) : MemberEvents
+        data class EditPermissions(val editMembers: List<MemberItem>) : MemberEvents
+    }
+
+    sealed interface AlbumSettingEvents {
+        data object DeleteAlbum : AlbumSettingEvents
+        data class ChangeImage(val imageUri: Uri) : AlbumSettingEvents
+        data object DeleteImage : AlbumSettingEvents
+        data class EditSubTitle(val subTitle: String) : AlbumSettingEvents
+        data object DeleteSubTitle : AlbumSettingEvents
+        data class EditTitle(val title: String) : AlbumSettingEvents
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailNavigation.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailNavigation.kt
@@ -1,32 +1,46 @@
 package cord.eoeo.momentwo.ui.albumdetail
 
 import androidx.navigation.NavHostController
+import kotlinx.serialization.Serializable
 
-object AlbumDetailDestination {
-    const val SUB_ALBUM_LIST_ROUTE = "sub_album_list"
-    const val MEMBER_ROUTE = "member"
-    const val ALBUM_SETTING_ROUTE = "album_setting"
+sealed interface AlbumDetailDestination {
+    @Serializable
+    data object SubAlbumList : AlbumDetailDestination
+
+    @Serializable
+    data object Member : AlbumDetailDestination
+
+    @Serializable
+    data object AlbumSetting : AlbumDetailDestination
+
+    @Serializable
+    data object ChangeImage : AlbumDetailDestination
 }
 
 class AlbumDetailNavigationActions(
     navController: NavHostController,
 ) {
+    val popBackStack: () -> Unit = {
+        navController.popBackStack()
+    }
     val navigateToSubAlbumList: () -> Unit = {
-        navController.navigate(AlbumDetailDestination.SUB_ALBUM_LIST_ROUTE) {
+        navController.navigate(AlbumDetailDestination.SubAlbumList) {
             launchSingleTop = true
-            popUpTo(navController.graph.id)
         }
     }
     val navigateToMember: () -> Unit = {
-        navController.navigate(AlbumDetailDestination.MEMBER_ROUTE) {
+        navController.navigate(AlbumDetailDestination.Member) {
             launchSingleTop = true
-            popUpTo(navController.graph.id)
         }
     }
     val navigateToAlbumSetting: () -> Unit = {
-        navController.navigate(AlbumDetailDestination.ALBUM_SETTING_ROUTE) {
+        navController.navigate(AlbumDetailDestination.AlbumSetting) {
             launchSingleTop = true
-            popUpTo(navController.graph.id)
+        }
+    }
+    val navigateToChangeImage: () -> Unit = {
+        navController.navigate(AlbumDetailDestination.ChangeImage) {
+            launchSingleTop = true
         }
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
@@ -1,18 +1,29 @@
 package cord.eoeo.momentwo.ui.albumdetail
 
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import cord.eoeo.momentwo.data.member.MemberRepository
+import cord.eoeo.momentwo.data.subalbum.SubAlbumRepository
+import cord.eoeo.momentwo.domain.album.AlbumRepository
+import cord.eoeo.momentwo.domain.friend.GetFriendListUseCase
 import cord.eoeo.momentwo.ui.BaseViewModel
 import cord.eoeo.momentwo.ui.MomentwoDestination
 import cord.eoeo.momentwo.ui.model.AlbumItem
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class AlbumDetailViewModel
 @Inject
 constructor(
-    savedStateHandle: SavedStateHandle
+    private val getFriendListUseCase: GetFriendListUseCase,
+    private val subAlbumRepository: SubAlbumRepository,
+    private val memberRepository: MemberRepository,
+    private val albumRepository: AlbumRepository,
+    savedStateHandle: SavedStateHandle,
 ) :
     BaseViewModel<AlbumDetailContract.State, AlbumDetailContract.Event, AlbumDetailContract.Effect>() {
     init {
@@ -28,11 +39,364 @@ constructor(
     override fun handleEvent(newEvent: AlbumDetailContract.Event) {
         when (newEvent) {
             is AlbumDetailContract.Event.OnChangeNavIndex -> {
-                with(uiState.value) { setState(copy(selectedNavIndex = newEvent.index)) }
+                with(uiState.value) { setState(copy(selectedNavIndex = newEvent.index, isEditMode = false)) }
+            }
+
+            is AlbumDetailContract.Event.OnGetFriendList -> {
+                viewModelScope.launch {
+                    with(uiState.value) {
+                        getFriendListUseCase().onSuccess { friends ->
+                            setState(copy(friendList = friends))
+                        }.onFailure { exception ->
+                            Log.e("AlbumDetail", "getFriendList onFailure", exception)
+                        }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnGetPermission -> {
+                viewModelScope.launch {
+                    with(uiState.value) {
+                        albumRepository
+                            .getAlbumRole(albumItem.id)
+                            .onSuccess { memberAuth ->
+                                setState(copy(permission = memberAuth))
+                            }.onFailure { exception ->
+                                Log.e("AlbumDetail", "getAlbumRole onFailure", exception)
+                            }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnChangeFriendSelected -> {
+                viewModelScope.launch {
+                    with(uiState.value) {
+                        val newSelectedList = selectedFriendList.toMutableList()
+
+                        if (newEvent.isSelected) {
+                            newSelectedList.add(newEvent.friendItem)
+                            setState(copy(selectedFriendList = newSelectedList))
+                        } else {
+                            newSelectedList.remove(newEvent.friendItem)
+                            setState(copy(selectedFriendList = newSelectedList))
+                        }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnChangeSubAlbumSelected -> {
+                viewModelScope.launch {
+                    with(uiState.value) {
+                        val newSelectedList = selectedSubAlbumIds.toMutableList()
+
+                        if (newEvent.isSelected) {
+                            newSelectedList.add(newEvent.subAlbumId)
+                            setState(copy(selectedSubAlbumIds = newSelectedList))
+                        } else {
+                            newSelectedList.remove(newEvent.subAlbumId)
+                            setState(copy(selectedSubAlbumIds = newSelectedList))
+                        }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnChangeMemberSelected -> {
+                viewModelScope.launch {
+                    with(uiState.value) {
+                        val newSelectedList = selectedMemberNicknames.toMutableList()
+
+                        if (newEvent.isSelected) {
+                            newSelectedList.add(newEvent.memberNickname)
+                            setState(copy(selectedMemberNicknames = newSelectedList))
+                        } else {
+                            newSelectedList.remove(newEvent.memberNickname)
+                            setState(copy(selectedMemberNicknames = newSelectedList))
+                        }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnClickAdd -> {
+                with(uiState.value) {
+                    if (selectedNavIndex == 0) {
+                        setEvent(AlbumDetailContract.Event.OnOpenTextFieldDialog(0))
+                    } else if (selectedNavIndex == 1) {
+                        setEvent(AlbumDetailContract.Event.OnClickInvite)
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnClickEdit -> {
+                with(uiState.value) { setState(copy(isEditMode = true)) }
+            }
+
+            is AlbumDetailContract.Event.OnCancelEdit -> {
+                with(uiState.value) {
+                    if (selectedNavIndex == 0) {
+                        setState(copy(isEditMode = false, selectedSubAlbumIds = emptyList()))
+                    } else if (selectedNavIndex == 1) {
+                        setState(copy(isEditMode = false, selectedMemberNicknames = emptyList()))
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnConfirmEdit -> {
+                viewModelScope.launch {
+                    with(uiState.value) {
+                        if (selectedNavIndex == 0) {
+                            setEvent(
+                                AlbumDetailContract.Event.OnSubAlbumEvents(
+                                    AlbumDetailContract.SubAlbumEvents.DeleteSubAlbums(selectedSubAlbumIds)
+                                )
+                            )
+                        } else if (selectedNavIndex == 1) {
+                            // TODO : 멤버 권한 수정 기능 구현, Long Click 옵션으로 추가?
+                            setEvent(
+                                AlbumDetailContract.Event.OnMemberEvents(
+                                    AlbumDetailContract.MemberEvents.KickMembers(selectedMemberNicknames)
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnOpenTextFieldDialog -> {
+                with(uiState.value) { setState(copy(textFieldDialogIndex = newEvent.index)) }
+            }
+
+            is AlbumDetailContract.Event.OnDismissTextFieldDialog -> {
+                with(uiState.value) { setState(copy(textFieldDialogIndex = -1)) }
+            }
+
+            is AlbumDetailContract.Event.OnClickInvite -> {
+                with(uiState.value) { setState(copy(isInviteDialogOpened = true)) }
+            }
+
+            is AlbumDetailContract.Event.OnDismissInviteFriend -> {
+                with(uiState.value) { setState(copy(isInviteDialogOpened = false, selectedFriendList = emptyList())) }
+            }
+
+            is AlbumDetailContract.Event.OnConfirmInviteFriend -> {
+                viewModelScope.launch {
+                    with(uiState.value) {
+                        memberRepository
+                            .requestInviteMembers(albumItem.id, selectedFriendList.map { it.nickname })
+                            .onSuccess {
+                                setEvent(AlbumDetailContract.Event.OnMemberEvents(AlbumDetailContract.MemberEvents.GetMembers))
+                                setState(copy(isInviteDialogOpened = false, selectedFriendList = emptyList()))
+                            }.onFailure { exception ->
+                                Log.e("AlbumDetail", "requestInviteMembers onFailure", exception)
+                            }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnChangeIsInChangeImage -> {
+                with(uiState.value) { setState(copy(isInChangeImage = newEvent.isInChangeImage)) }
+            }
+
+            is AlbumDetailContract.Event.OnSubAlbumEvents -> {
+                viewModelScope.launch {
+                    val albumId = uiState.value.albumItem.id
+
+                    with(newEvent.subAlbumEvents) {
+                        when (this) {
+                            is AlbumDetailContract.SubAlbumEvents.Create -> {
+                                subAlbumRepository
+                                    .requestCreateSubAlbum(albumId, subAlbumTitle)
+                                    .onSuccess {
+                                        setEvent(AlbumDetailContract.Event.OnSubAlbumEvents(AlbumDetailContract.SubAlbumEvents.GetSubAlbums))
+                                        setState(uiState.value.copy(textFieldDialogIndex = -1))
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "requestCreateSubAlbum onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.SubAlbumEvents.DeleteSubAlbums -> {
+                                subAlbumRepository
+                                    .deleteSubAlbums(albumId, subAlbumIds)
+                                    .onSuccess {
+                                        setEvent(AlbumDetailContract.Event.OnSubAlbumEvents(AlbumDetailContract.SubAlbumEvents.GetSubAlbums))
+                                        setState(uiState.value.copy(isEditMode = false))
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "deleteSubAlbums onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.SubAlbumEvents.EditTitle -> {
+                                subAlbumRepository
+                                    .changeSubAlbumTitle(albumId, subAlbumId, title)
+                                    .onSuccess { subAlbums ->
+                                        setEvent(AlbumDetailContract.Event.OnSubAlbumEvents(AlbumDetailContract.SubAlbumEvents.GetSubAlbums))
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "changeSubAlbumTitle onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.SubAlbumEvents.GetSubAlbums -> {
+                                subAlbumRepository
+                                    .getSubAlbumList(albumId)
+                                    .onSuccess { subAlbums ->
+                                        setState(uiState.value.copy(subAlbumList = subAlbums))
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "getSubAlbumList onFailure", exception)
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnMemberEvents -> {
+                viewModelScope.launch {
+                    val albumId = uiState.value.albumItem.id
+
+                    with(newEvent.memberEvents) {
+                        when (this) {
+                            is AlbumDetailContract.MemberEvents.AssignAdmin -> {
+                                memberRepository
+                                    .assignAdminToMember(albumId, nickname)
+                                    .onSuccess {
+                                        setEvent(AlbumDetailContract.Event.OnMemberEvents(AlbumDetailContract.MemberEvents.GetMembers))
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "assignAdminToMember onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.MemberEvents.EditPermissions -> {
+                                memberRepository
+                                    .editMembersPermission(albumId, editMembers)
+                                    .onSuccess {
+                                        setEvent(AlbumDetailContract.Event.OnMemberEvents(AlbumDetailContract.MemberEvents.GetMembers))
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "editMembersPermission onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.MemberEvents.Exit -> {
+                                memberRepository
+                                    .exitFromAlbum(albumId)
+                                    .onSuccess {
+                                        setEvent(AlbumDetailContract.Event.OnBack)
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "exitFromAlbum onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.MemberEvents.GetMembers -> {
+                                memberRepository
+                                    .getMemberList(albumId)
+                                    .onSuccess { members ->
+                                        setState(uiState.value.copy(memberList = members))
+                                    }
+                                    .onFailure { exception ->
+                                        Log.e("AlbumDetail", "getMemberList onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.MemberEvents.KickMembers -> {
+                                memberRepository
+                                    .kickMembers(albumId, kickMembers)
+                                    .onSuccess {
+                                        setEvent(AlbumDetailContract.Event.OnMemberEvents(AlbumDetailContract.MemberEvents.GetMembers))
+                                        setState(uiState.value.copy(isEditMode = false))
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "kickMembers onFailure", exception)
+                                    }
+                            }
+                        }
+                    }
+                }
+            }
+
+            is AlbumDetailContract.Event.OnAlbumSettingEvents -> {
+                viewModelScope.launch {
+                    val albumId = uiState.value.albumItem.id
+
+                    with(newEvent.albumSettingEvents) {
+                        when (this) {
+                            is AlbumDetailContract.AlbumSettingEvents.ChangeImage -> {
+                                albumRepository
+                                    .changeAlbumImage(albumId, imageUri)
+                                    .onFailure { exception ->
+                                        Log.e("AlbumDetail", "changeAlbumImage onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.AlbumSettingEvents.DeleteAlbum -> {
+                                albumRepository
+                                    .deleteAlbum(albumId)
+                                    .onSuccess {
+                                        setEvent(AlbumDetailContract.Event.OnBack)
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "deleteAlbum onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.AlbumSettingEvents.DeleteImage -> {
+                                albumRepository
+                                    .deleteAlbumImage(albumId)
+                                    .onFailure { exception ->
+                                        Log.e("AlbumDetail", "deleteAlbumImage onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.AlbumSettingEvents.DeleteSubTitle -> {
+                                albumRepository
+                                    .deleteAlbumSubTitle(albumId)
+                                    .onSuccess {
+                                        setState(
+                                            uiState.value.copy(
+                                                albumItem = uiState.value.albumItem.copy(subTitle = ""),
+                                                textFieldDialogIndex = -1,
+                                            )
+                                        )
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "deleteAlbumSubTitle onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.AlbumSettingEvents.EditTitle -> {
+                                albumRepository
+                                    .changeAlbumTitle(albumId, title)
+                                    .onSuccess {
+                                        setState(
+                                            uiState.value.copy(
+                                                albumItem = uiState.value.albumItem.copy(title = title),
+                                                textFieldDialogIndex = -1,
+                                            )
+                                        )
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "changeAlbumTitle onFailure", exception)
+                                    }
+                            }
+
+                            is AlbumDetailContract.AlbumSettingEvents.EditSubTitle -> {
+                                albumRepository
+                                    .changeAlbumSubTitle(albumId, subTitle)
+                                    .onSuccess {
+                                        setState(
+                                            uiState.value.copy(
+                                                albumItem = uiState.value.albumItem.copy(subTitle = subTitle),
+                                                textFieldDialogIndex = -1,
+                                            )
+                                        )
+                                    }.onFailure { exception ->
+                                        Log.e("AlbumDetail", "changeAlbumSubTitle onFailure", exception)
+                                    }
+                            }
+                        }
+                    }
+                }
             }
 
             is AlbumDetailContract.Event.OnBack -> {
                 setEffect { AlbumDetailContract.Effect.PopBackStack }
+            }
+
+            is AlbumDetailContract.Event.OnBackInAlbumDetail -> {
+                setEffect { AlbumDetailContract.Effect.PopBackStackInAlbumDetail }
             }
 
             is AlbumDetailContract.Event.OnError -> {

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingRoute.kt
@@ -1,15 +1,31 @@
 package cord.eoeo.momentwo.ui.albumdetail.albumsetting
 
 import androidx.compose.foundation.gestures.rememberScrollableState
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import cord.eoeo.momentwo.ui.model.MemberAuth
 
 @Composable
-fun AlbumSettingRoute(memberAuth: () -> MemberAuth) {
+fun AlbumSettingRoute(
+    memberAuth: () -> MemberAuth,
+    onOpenTextFieldDialog: (Int) -> Unit,
+    onClickChangeImage: () -> Unit,
+    onDeleteAlbum: () -> Unit,
+    onExitAlbum: () -> Unit,
+    onBack: () -> Unit,
+) {
     val scrollableState = rememberScrollableState { 1f }
+    val textColor = if (isSystemInDarkTheme()) Color.Gray else Color.DarkGray
 
     AlbumSettingScreen(
         scrollableState = scrollableState,
         memberAuth = memberAuth,
+        textColor = { textColor },
+        onOpenTextFieldDialog = onOpenTextFieldDialog,
+        onClickChangeImage = onClickChangeImage,
+        onDeleteAlbum = onDeleteAlbum,
+        onExitAlbum = onExitAlbum,
+        onBack = onBack,
     )
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingScreen.kt
@@ -1,35 +1,95 @@
 package cord.eoeo.momentwo.ui.albumdetail.albumsetting
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.ScrollableState
 import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.NavigateNext
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import cord.eoeo.momentwo.ui.model.MemberAuth
 
 @Composable
 fun AlbumSettingScreen(
     scrollableState: ScrollableState,
     memberAuth: () -> MemberAuth,
+    textColor: () -> Color,
+    onOpenTextFieldDialog: (Int) -> Unit,
+    onClickChangeImage: () -> Unit,
+    onDeleteAlbum: () -> Unit,
+    onExitAlbum: () -> Unit,
+    onBack: () -> Unit,
 ) {
+    BackHandler(onBack = onBack)
+
     Column(
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .scrollable(state = scrollableState, orientation = Orientation.Vertical),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+            .scrollable(state = scrollableState, orientation = Orientation.Vertical),
     ) {
-        AlbumSettingListItem(text = { "앨범 제목 수정" }, onClick = { /* TODO */ })
-        AlbumSettingListItem(text = { "대표 이미지 수정" }, onClick = { /* TODO */ })
-        if (memberAuth() == MemberAuth.ADMIN) {
-            AlbumSettingListItem(text = { "멤버 관리" }, onClick = { /* TODO */ })
+        if (memberAuth() != MemberAuth.MEMBER) {
+            Text(
+                text = "관리자 설정",
+                fontSize = 13.sp,
+                color = textColor(),
+                modifier = Modifier.padding(vertical = 8.dp),
+            )
+            OutlinedCard {
+                AlbumSettingListItem(
+                    text = { "앨범 제목 수정" },
+                    onClick = {
+                        onOpenTextFieldDialog(1)
+                    },
+                )
+                AlbumSettingListItem(
+                    text = { "앨범 부제목 수정" },
+                    onClick = {
+                        onOpenTextFieldDialog(2)
+                    },
+                )
+                AlbumSettingListItem(
+                    text = { "대표 이미지 수정" },
+                    onClick = onClickChangeImage,
+                )
+                if (memberAuth() == MemberAuth.ADMIN) {
+                    // TODO: Dialog 추가
+                    AlbumSettingListItem(
+                        text = { "앨범 삭제" },
+                        onClick = onDeleteAlbum,
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "앨범 설정",
+            fontSize = 13.sp,
+            color = textColor(),
+            modifier = Modifier.padding(vertical = 8.dp),
+        )
+        OutlinedCard {
+            // TODO: Dialog 추가
+            AlbumSettingListItem(
+                text = { "앨범 나가기" },
+                onClick = onExitAlbum,
+            )
         }
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageRoute.kt
@@ -1,0 +1,35 @@
+package cord.eoeo.momentwo.ui.albumdetail.albumsetting
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import coil.ImageLoader
+
+@Composable
+fun ChangeImageRoute(
+    imageLoader: ImageLoader,
+    imageUrl: () -> String,
+    onChangeIsInChangeImage: (Boolean) -> Unit,
+    onClickChange: (Uri?) -> Unit,
+    onBack: () -> Unit,
+) {
+    var imageUri: Uri? by rememberSaveable { mutableStateOf(Uri.parse(imageUrl())) }
+    val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        imageUri = uri ?: imageUri
+    }
+
+    ChangeImageScreen(
+        imageLoader = imageLoader,
+        imageUri = { imageUri },
+        onChangeIsInChangeImage = onChangeIsInChangeImage,
+        onClickSelect = { galleryLauncher.launch("image/*") },
+        onClickChange = { onClickChange(imageUri) },
+        onClickReset = { imageUri = null },
+        onBack = onBack,
+    )
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
@@ -1,0 +1,103 @@
+package cord.eoeo.momentwo.ui.albumdetail.albumsetting
+
+import android.net.Uri
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil.ImageLoader
+import coil.compose.AsyncImage
+import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+
+@Composable
+fun ChangeImageScreen(
+    imageLoader: ImageLoader,
+    imageUri: () -> Uri?,
+    onChangeIsInChangeImage: (Boolean) -> Unit,
+    onClickSelect: () -> Unit,
+    onClickChange: () -> Unit,
+    onClickReset: () -> Unit,
+    onBack: () -> Unit,
+) {
+    LaunchedEffect(SIDE_EFFECTS_KEY) {
+        onChangeIsInChangeImage(true)
+    }
+
+    BackHandler(onBack = onBack)
+
+    Column(
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+    ) {
+        AsyncImage(
+            model = imageUri(),
+            contentDescription = "앨범 대표 이미지",
+            imageLoader = imageLoader,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .padding(8.dp)
+                .clip(RoundedCornerShape(8.dp))
+                .background(color = Color.Gray),
+        )
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 16.dp)
+        ) {
+            Row(
+                horizontalArrangement = Arrangement.SpaceAround,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Button(
+                    onClick = onClickSelect,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                    ),
+                ) {
+                    Text("이미지 선택")
+                }
+
+                Button(onClick = { /* TODO */ }) {
+                    Text("이미지 변경")
+                }
+            }
+
+            Button(
+                onClick = onClickReset,
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.errorContainer,
+                    contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                ),
+                modifier = Modifier
+                    .padding(16.dp)
+                    .align(Alignment.CenterHorizontally),
+            ) {
+                Text("이미지 초기화")
+            }
+        }
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberListItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberListItem.kt
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.ui.albumdetail.member
 
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -13,7 +14,9 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,14 +29,54 @@ import cord.eoeo.momentwo.ui.model.MemberItem
 import cord.eoeo.momentwo.ui.theme.starYellow
 
 @Composable
-fun MemberListItem(memberItem: () -> MemberItem) {
+fun MemberListItem(
+    memberItem: () -> MemberItem,
+    isEditMode: () -> Boolean,
+    getIsSelected: (String) -> Boolean,
+    onChangeMemberSelected: (Boolean, String) -> Unit,
+) {
+    val isSelected = getIsSelected(memberItem().nickname)
+    val authColor = with(MaterialTheme.colorScheme) {
+        when (memberItem().auth) {
+            MemberAuth.ADMIN -> error
+            MemberAuth.SUB_ADMIN -> tertiary
+            MemberAuth.MEMBER -> if (isSystemInDarkTheme()) Color.White else Color.Black
+        }
+    }
+
+    MemberListItemScreen(
+        memberItem = memberItem,
+        isEditMode = isEditMode,
+        authColor = { authColor },
+        isSelected = { isSelected },
+        onSelectedChange = { onChangeMemberSelected(it, memberItem().nickname) },
+    )
+}
+
+@Composable
+fun MemberListItemScreen(
+    memberItem: () -> MemberItem,
+    isEditMode: () -> Boolean,
+    authColor: () -> Color,
+    isSelected: () -> Boolean,
+    onSelectedChange: (Boolean) -> Unit,
+) {
     Row(
-        modifier =
-            Modifier
-                .height(60.dp)
-                .fillMaxWidth()
-                .padding(horizontal = 12.dp, vertical = 8.dp),
+        modifier = Modifier
+            .height(60.dp)
+            .fillMaxWidth()
+            .padding(horizontal = 12.dp, vertical = 8.dp),
     ) {
+        if (isEditMode()) {
+            Checkbox(
+                checked = isSelected(),
+                onCheckedChange = onSelectedChange,
+                modifier = Modifier
+                    .fillMaxHeight()
+                    .wrapContentHeight(align = Alignment.CenterVertically),
+            )
+        }
+
         Box(modifier = Modifier.size(60.dp)) {
             Icon(
                 imageVector = Icons.Default.AccountCircle,
@@ -49,25 +92,26 @@ fun MemberListItem(memberItem: () -> MemberItem) {
                 )
             }
         }
+
         Text(
             text = memberItem().nickname,
             fontSize = 18.sp,
-            modifier =
-                Modifier
-                    .fillMaxHeight()
-                    .wrapContentHeight(align = Alignment.CenterVertically)
-                    .padding(start = 8.dp),
+            modifier = Modifier
+                .fillMaxHeight()
+                .wrapContentHeight(align = Alignment.CenterVertically)
+                .padding(start = 8.dp),
         )
+
         Spacer(modifier = Modifier.weight(1f))
+
         Text(
             text = memberItem().auth.authString,
             fontSize = 14.sp,
-            color = Color.DarkGray,
-            modifier =
-                Modifier
-                    .fillMaxHeight()
-                    .wrapContentHeight(align = Alignment.CenterVertically)
-                    .padding(end = 8.dp),
+            color = authColor(),
+            modifier = Modifier
+                .fillMaxHeight()
+                .wrapContentHeight(align = Alignment.CenterVertically)
+                .padding(end = 8.dp),
         )
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberScreen.kt
@@ -1,32 +1,43 @@
 package cord.eoeo.momentwo.ui.albumdetail.member
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import cord.eoeo.momentwo.ui.model.MemberAuth
+import androidx.lifecycle.compose.LifecycleStartEffect
+import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.model.MemberItem
 
 @Composable
-fun MemberScreen() {
-    val memberItems =
-        listOf(
-            MemberItem("User1", MemberAuth.ADMIN),
-            MemberItem("User2", MemberAuth.SUB_ADMIN),
-            MemberItem("User3", MemberAuth.SUB_ADMIN),
-            MemberItem("User4", MemberAuth.MEMBER),
-            MemberItem("User5", MemberAuth.MEMBER),
-            MemberItem("User6", MemberAuth.MEMBER),
-            MemberItem("User7", MemberAuth.MEMBER),
-            MemberItem("User8", MemberAuth.MEMBER),
-        )
+fun MemberScreen(
+    memberList: () -> List<MemberItem>,
+    isEditMode: () -> Boolean,
+    getMembers: () -> Unit,
+    getFriends: () -> Unit,
+    getIsSelected: (String) -> Boolean,
+    onChangeMemberSelected: (Boolean, String) -> Unit,
+    onBack: () -> Unit,
+) {
+    LifecycleStartEffect(START_EFFECTS_KEY) {
+        getMembers()
+        getFriends()
+        onStopOrDispose { }
+    }
+
+    BackHandler(onBack = onBack)
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
     ) {
-        items(items = memberItems, key = { it.nickname }) { item ->
-            MemberListItem(memberItem = { item })
+        items(items = memberList(), key = { it.nickname }) { item ->
+            MemberListItem(
+                memberItem = { item },
+                isEditMode = isEditMode,
+                getIsSelected = getIsSelected,
+                onChangeMemberSelected = onChangeMemberSelected,
+            )
         }
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumItemCard.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumItemCard.kt
@@ -1,48 +1,139 @@
 package cord.eoeo.momentwo.ui.albumdetail.subalbumlist
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CheckboxDefaults
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import coil.ImageLoader
+import coil.compose.AsyncImage
 import cord.eoeo.momentwo.ui.model.SubAlbumItem
 
 @Composable
 fun SubAlbumItemCard(
+    imageLoader: ImageLoader,
     subAlbumItem: () -> SubAlbumItem,
+    isEditMode: () -> Boolean,
+    getIsSelected: (Int) -> Boolean,
+    onClick: () -> Unit,
+    onChangeSubAlbumSelected: (Boolean, Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier =
-            modifier
+    val isSelected = getIsSelected(subAlbumItem().id)
+    val cardColors = if (isSelected && isEditMode()) {
+        CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.tertiaryContainer)
+    } else {
+        CardDefaults.cardColors()
+    }
+
+    SubAlbumItemCardScreen(
+        imageLoader = imageLoader,
+        subAlbumItem = subAlbumItem,
+        isSelected = { isSelected },
+        cardColors = { cardColors },
+        isEditMode = isEditMode,
+        onClick = onClick,
+        onSelectedChange = { onChangeSubAlbumSelected(it, subAlbumItem().id) },
+        modifier = modifier
+    )
+}
+
+@Composable
+fun SubAlbumItemCardScreen(
+    imageLoader: ImageLoader,
+    subAlbumItem: () -> SubAlbumItem,
+    isSelected: () -> Boolean,
+    cardColors: () -> CardColors,
+    isEditMode: () -> Boolean,
+    onClick: () -> Unit,
+    onSelectedChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box {
+        Column(
+            modifier = modifier
                 .fillMaxWidth()
                 .padding(16.dp),
-    ) {
-        ElevatedCard(
-            onClick = { /*TODO: Navigate to PhotoList*/ },
-            modifier =
-                Modifier
+        ) {
+            ElevatedCard(
+                onClick = {
+                    if (isEditMode().not()) {
+                        onClick()
+                    } else {
+                        onSelectedChange(isSelected().not())
+                    }
+                },
+                colors = cardColors(),
+                modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(1f),
-        ) {
-            // TODO: 서브 앨범 대표사진 Grid 구현, SubAlbumItem에 대표 사진 목록 필요 (최대 4개 사진), Coil ImageLoader 필요
-        }
+            ) {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    contentPadding = PaddingValues(4.dp),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(4.dp),
+                ) {
+                    items(items = subAlbumItem().imageList, key = { it.id }) { item ->
+                        AsyncImage(
+                            model = item.imageUrl,
+                            contentDescription = "서브 앨범 대표 이미지",
+                            imageLoader = imageLoader,
+                            contentScale = ContentScale.Crop,
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1f)
+                                .padding(4.dp)
+                                .clip(RoundedCornerShape(4.dp)),
+                        )
+                    }
+                }
+            }
 
-        Text(
-            text = subAlbumItem().title,
-            maxLines = 1,
-            fontWeight = FontWeight.SemiBold,
-            textAlign = TextAlign.Center,
-            modifier =
-                Modifier
+            Text(
+                text = subAlbumItem().title,
+                maxLines = 1,
+                fontWeight = FontWeight.SemiBold,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
                     .fillMaxWidth()
                     .padding(0.dp, 8.dp, 0.dp, 0.dp),
-        )
+            )
+        }
+
+        if (isEditMode()) {
+            Checkbox(
+                checked = isSelected(),
+                onCheckedChange = onSelectedChange,
+                colors = CheckboxDefaults.colors()
+                    .copy(uncheckedBoxColor = Color.Gray, uncheckedBorderColor = Color.Gray),
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(8.dp),
+            )
+        }
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumListScreen.kt
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.ui.albumdetail.subalbumlist
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -9,39 +10,45 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.LifecycleStartEffect
+import coil.ImageLoader
+import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.model.SubAlbumItem
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun SubAlbumListScreen() {
-    val fakeItems =
-        listOf(
-            SubAlbumItem(1, "Sub1", emptyList()),
-            SubAlbumItem(2, "Sub2", emptyList()),
-            SubAlbumItem(3, "Sub3", emptyList()),
-            SubAlbumItem(4, "Sub4", emptyList()),
-            SubAlbumItem(5, "Sub5", emptyList()),
-            SubAlbumItem(6, "Sub6", emptyList()),
-            SubAlbumItem(7, "Sub7", emptyList()),
-            SubAlbumItem(8, "Sub8", emptyList()),
-            SubAlbumItem(9, "Sub9", emptyList()),
-            SubAlbumItem(10, "Sub10", emptyList()),
-            SubAlbumItem(11, "Sub11", emptyList()),
-            SubAlbumItem(12, "Sub12", emptyList()),
-            SubAlbumItem(13, "Sub13", emptyList()),
-        )
+fun SubAlbumListScreen(
+    imageLoader: ImageLoader,
+    subAlbumList: () -> List<SubAlbumItem>,
+    isEditMode: () -> Boolean,
+    getSubAlbums: () -> Unit,
+    getIsSelected: (Int) -> Boolean,
+    onClickItem: () -> Unit,
+    onChangeSubAlbumSelected: (Boolean, Int) -> Unit,
+    onBack: () -> Unit,
+) {
+    LifecycleStartEffect(START_EFFECTS_KEY) {
+        getSubAlbums()
+        onStopOrDispose { }
+    }
+
+    BackHandler(onBack = onBack)
 
     LazyVerticalGrid(
         columns = GridCells.Adaptive(minSize = 160.dp),
-        modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(8.dp, 0.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(8.dp, 0.dp),
     ) {
-        items(items = fakeItems, key = { it.id }) { item ->
+        items(items = subAlbumList(), key = { it.id }) { item ->
             SubAlbumItemCard(
+                imageLoader = imageLoader,
                 subAlbumItem = { item },
-                modifier = Modifier.animateItemPlacement(),
+                isEditMode = isEditMode,
+                getIsSelected = getIsSelected,
+                onClick = onClickItem,
+                onChangeSubAlbumSelected = onChangeSubAlbumSelected,
+                modifier = Modifier.animateItem()
             )
         }
     }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/CheckboxListItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/CheckboxListItem.kt
@@ -1,13 +1,20 @@
 package cord.eoeo.momentwo.ui.composable
 
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
-import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun CheckboxListItem(
@@ -31,14 +38,30 @@ fun CheckboxListItemScreen(
     onCheckedChange: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    ListItem(
-        leadingContent = { Icon(Icons.Default.AccountCircle, "") },
-        headlineContent = { Text(text = itemText()) },
-        trailingContent = {
-            Checkbox(
-                checked = isChecked(),
-                onCheckedChange = onCheckedChange,
-            )
-        },
-    )
+    Row(
+        modifier = Modifier
+            .height(60.dp)
+            .padding(horizontal = 16.dp, vertical = 4.dp),
+    ) {
+        Icon(
+            imageVector = Icons.Default.AccountCircle,
+            contentDescription = "",
+            modifier = Modifier
+                .fillMaxHeight()
+                .aspectRatio(1f)
+                .padding(8.dp),
+        )
+        Text(
+            text = itemText(),
+            modifier = Modifier
+                .fillMaxHeight()
+                .wrapContentHeight(align = Alignment.CenterVertically)
+                .weight(1f),
+        )
+        Checkbox(
+            checked = isChecked(),
+            onCheckedChange = onCheckedChange,
+            modifier = Modifier.fillMaxHeight(),
+        )
+    }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/InviteDialog.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/InviteDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -39,8 +40,7 @@ import cord.eoeo.momentwo.ui.model.UserItem
 fun InviteDialog(
     friendItemList: () -> List<FriendItem>,
     selectedFriendList: () -> List<FriendItem>,
-    getIsChecked: (String) -> Boolean,
-    onClickClear: (FriendItem) -> Unit,
+    getIsChecked: (FriendItem) -> Boolean,
     onCheckedChange: (Boolean, FriendItem) -> Unit,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
@@ -56,7 +56,6 @@ fun InviteDialog(
         getIsChecked = getIsChecked,
         onQueryChange = { searchQuery = it },
         onSearch = { searchQuery = it },
-        onClickClear = onClickClear,
         onCheckedChange = onCheckedChange,
         onDismiss = onDismiss,
         onConfirm = { onConfirm() },
@@ -70,10 +69,9 @@ fun InviteDialogScreen(
     searchRegex: () -> Regex,
     friendItemList: () -> List<FriendItem>,
     selectedFriendList: () -> List<FriendItem>,
-    getIsChecked: (String) -> Boolean,
+    getIsChecked: (FriendItem) -> Boolean,
     onQueryChange: (String) -> Unit,
     onSearch: (String) -> Unit,
-    onClickClear: (FriendItem) -> Unit,
     onCheckedChange: (Boolean, FriendItem) -> Unit,
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
@@ -81,49 +79,54 @@ fun InviteDialogScreen(
     Dialog(
         onDismissRequest = onDismiss,
         properties =
-            DialogProperties(
-                usePlatformDefaultWidth = false,
-            ),
+        DialogProperties(
+            usePlatformDefaultWidth = false,
+        ),
     ) {
         Card(
             modifier = Modifier.fillMaxSize(),
             shape = RoundedCornerShape(16.dp),
         ) {
             SearchBar(
-                query = searchQuery(),
-                onQueryChange = onQueryChange,
-                onSearch = onSearch,
-                active = true,
-                onActiveChange = { },
-                placeholder = { Text(text = "친구 검색") },
-                leadingIcon = {
-                    IconButton(onClick = onDismiss) {
-                        Icon(Icons.AutoMirrored.Default.ArrowBack, "")
-                    }
+                inputField = {
+                    SearchBarDefaults.InputField(
+                        query = searchQuery(),
+                        onQueryChange = onQueryChange,
+                        onSearch = onSearch,
+                        expanded = false,
+                        onExpandedChange = { },
+                        placeholder = { Text(text = "친구 검색") },
+                        leadingIcon = {
+                            IconButton(onClick = onDismiss) {
+                                Icon(Icons.AutoMirrored.Default.ArrowBack, "")
+                            }
+                        },
+                        trailingIcon = {
+                            if (searchQuery().isNotEmpty()) {
+                                IconButton(onClick = { onQueryChange("") }) {
+                                    Icon(Icons.Default.Clear, "")
+                                }
+                            }
+                        },
+                    )
                 },
-                trailingIcon = {
-                    if (searchQuery().isNotEmpty()) {
-                        IconButton(onClick = { onQueryChange("") }) {
-                            Icon(Icons.Default.Clear, "")
-                        }
-                    }
-                },
+                expanded = true,
+                onExpandedChange = { },
+                modifier = Modifier.fillMaxWidth()
             ) {
                 if (selectedFriendList().isNotEmpty()) {
                     LazyRow(
-                        modifier =
-                            Modifier
-                                .height(80.dp)
-                                .fillMaxWidth(),
+                        modifier = Modifier
+                            .height(80.dp)
+                            .fillMaxWidth(),
                     ) {
                         items(items = selectedFriendList(), key = { it.nickname }) { friendItem ->
                             UserItemBox(
                                 userItem = { UserItem(0, friendItem.nickname) },
                                 onClickClear = { onCheckedChange(false, friendItem) },
-                                modifier =
-                                    Modifier
-                                        .animateItemPlacement()
-                                        .fillMaxHeight(),
+                                modifier = Modifier
+                                    .animateItem()
+                                    .fillMaxHeight(),
                             )
                         }
                     }
@@ -133,9 +136,9 @@ fun InviteDialogScreen(
 
                 LazyColumn(
                     modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .weight(1f),
+                    Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
                 ) {
                     items(
                         items = friendItemList().filter { it.nickname.contains(searchRegex()) },
@@ -144,11 +147,10 @@ fun InviteDialogScreen(
                         CheckboxListItem(
                             itemText = { friendItem.nickname },
                             onCheckedChange = { onCheckedChange(it, friendItem) },
-                            isChecked = { getIsChecked(friendItem.nickname) },
-                            modifier =
-                                Modifier
-                                    .animateItemPlacement()
-                                    .fillMaxWidth(),
+                            isChecked = { getIsChecked(friendItem) },
+                            modifier = Modifier
+                                .animateItem()
+                                .fillMaxWidth(),
                         )
                     }
                 }
@@ -158,9 +160,9 @@ fun InviteDialogScreen(
                 Row(
                     horizontalArrangement = Arrangement.End,
                     modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp),
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(8.dp),
                 ) {
                     TextButton(onClick = onConfirm) {
                         Text(text = "완료")

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/TextFieldDialog.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/TextFieldDialog.kt
@@ -1,0 +1,123 @@
+package cord.eoeo.momentwo.ui.composable
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import cord.eoeo.momentwo.ui.theme.MomentwoTheme
+
+@Composable
+fun TextFieldDialog(
+    titleText: () -> String,
+    description: () -> String,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+    initialText: () -> String = { "" },
+) {
+    var text: String by rememberSaveable { mutableStateOf(initialText()) }
+
+    TextFieldDialogScreen(
+        titleText = titleText,
+        description = description,
+        text = { text },
+        onTextChange = { text = it },
+        onDismiss = onDismiss,
+        onConfirm = onConfirm,
+    )
+}
+
+@Composable
+fun TextFieldDialogScreen(
+    titleText: () -> String,
+    description: () -> String,
+    text: () -> String,
+    onTextChange: (String) -> Unit,
+    onDismiss: () -> Unit,
+    onConfirm: (String) -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Card(
+            shape = RoundedCornerShape(16.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 24.dp, vertical = 16.dp)
+            ) {
+                Text(
+                    text = titleText(),
+                    fontSize = 20.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                )
+
+                Text(
+                    text = description(),
+                    fontSize = 14.sp,
+                    color = Color.DarkGray,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                )
+
+                OutlinedTextField(
+                    value = text(),
+                    onValueChange = onTextChange,
+                    singleLine = true,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
+                )
+
+                Row(
+                    horizontalArrangement = Arrangement.End,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    TextButton(onClick = onDismiss) {
+                        Text(text = "취소", color = MaterialTheme.colorScheme.error)
+                    }
+                    TextButton(onClick = { onConfirm(text()) }) {
+                        Text(text = "확인", color = MaterialTheme.colorScheme.primary)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun TextFieldDialogPreview() {
+    MomentwoTheme {
+        TextFieldDialog(
+            titleText = { "Title" },
+            description = { "desc" },
+            initialText = { "init" },
+            onDismiss = {},
+            onConfirm = {},
+        )
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
@@ -84,7 +84,6 @@ fun CreateAlbumScreen(
         InviteDialog(
             friendItemList = { uiState().friendList },
             selectedFriendList = { uiState().tempSelectedFriendList },
-            onClickClear = { onEvent(CreateAlbumContract.Event.OnCheckedChange(false, it)) },
             onCheckedChange = { isChecked, friendItem ->
                 onEvent(
                     CreateAlbumContract.Event.OnCheckedChange(
@@ -93,7 +92,7 @@ fun CreateAlbumScreen(
                     ),
                 )
             },
-            getIsChecked = { uiState().tempSelectedFriendMap[it] ?: false },
+            getIsChecked = { uiState().tempSelectedFriendMap[it.nickname] == true },
             onDismiss = { onEvent(CreateAlbumContract.Event.OnDismissInviteFriend) },
             onConfirm = { onEvent(CreateAlbumContract.Event.OnConfirmInviteFriend) },
         )
@@ -154,14 +153,14 @@ fun CreateAlbumScreen(
                         onClickClear = { onEvent(CreateAlbumContract.Event.OnClearFriendItem(it)) },
                         modifier =
                             Modifier
-                                .animateItemPlacement()
+                                .animateItem()
                                 .fillMaxWidth(),
                     )
                 }
             }
 
             ConfirmExtendedFAB(
-                onClick = { /*TODO: Create Album & Navigate to Album*/ },
+                onClick = { onEvent(CreateAlbumContract.Event.OnRequestCreateAlbum(title())) },
                 modifier =
                     Modifier
                         .align(Alignment.End)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/model/TextFieldDialogItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/model/TextFieldDialogItem.kt
@@ -1,0 +1,8 @@
+package cord.eoeo.momentwo.ui.model
+
+data class TextFieldDialogItem(
+    val titleText: String,
+    val description: String,
+    val onConfirm: (String) -> Unit,
+    val initialText: String = "",
+)


### PR DESCRIPTION
## PR 내용
### 앨범 디테일 화면 수정
- 서브 앨범 대표사진 Grid 구현
- 멤버 권한 폰트 색상 적용
- 서브앨범 삭제 기능
- 멤버 수정(추방) 기능
- 앨범 설정 목록 클릭 시 해당 기능 화면으로 이동해 수정할 수 있도록 구현
    - 멤버는 앨범 나가기만
    - 앨범 대표 이미지 업로드 - 갤러리에서 선택

### 앨범 기능 연결
- 앨범 설정 기능 연결 (앨범 이미지, 타이틀, 서브타이틀 수정, 앨범 삭제)
- 서브 앨범 기능 구현, 연결
- 멤버 기능 구현, 연결

Resolve: #45 