### PR TITLE
이미지 업로드 수정 (Pre-Signed, CloudFront 적용 대응)

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
@@ -24,6 +24,7 @@ object MomentwoApi {
     const val GET_ALBUM_LIST = "/albums"
     /** Require @Path("albumId") */
     const val GET_ALBUM_ROLE = "/albums/rules/{albumId}"
+    const val POST_ALBUM_PRESIGNED = "/images/albums/profiles/presigned"
 
     // SubAlbum
     const val POST_CREATE_SUBALBUM = "/album/sub/create"

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumDataSource.kt
@@ -6,11 +6,15 @@ import cord.eoeo.momentwo.data.model.AlbumRole
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import cord.eoeo.momentwo.data.model.EditAlbumTitle
+import cord.eoeo.momentwo.data.model.PresignedRequest
+import cord.eoeo.momentwo.data.model.PresignedUrl
 
 interface AlbumDataSource {
     suspend fun requestCreateAlbum(createAlbumInfo: CreateAlbumInfo): Result<Unit>
 
     suspend fun deleteAlbum(albumId: Int): Result<Unit>
+
+    suspend fun requestPresignedUrl(presignedRequest: PresignedRequest): Result<PresignedUrl>
 
     suspend fun changeAlbumImage(albumImage: AlbumImage): Result<Unit>
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumRemoteDataSource.kt
@@ -7,6 +7,8 @@ import cord.eoeo.momentwo.data.model.AlbumRole
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import cord.eoeo.momentwo.data.model.EditAlbumTitle
+import cord.eoeo.momentwo.data.model.PresignedRequest
+import cord.eoeo.momentwo.data.model.PresignedUrl
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -26,6 +28,13 @@ class AlbumRemoteDataSource(
         runCatching {
             withContext(dispatcher) {
                 albumService.deleteAlbum(albumId)
+            }
+        }
+
+    override suspend fun requestPresignedUrl(presignedRequest: PresignedRequest): Result<PresignedUrl> =
+        runCatching {
+            withContext(dispatcher) {
+                albumService.postAlbumPresigned(presignedRequest)
             }
         }
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
@@ -7,13 +7,14 @@ import cord.eoeo.momentwo.data.model.AlbumRole
 import cord.eoeo.momentwo.data.model.AlbumSubTitle
 import cord.eoeo.momentwo.data.model.CreateAlbumInfo
 import cord.eoeo.momentwo.data.model.EditAlbumTitle
+import cord.eoeo.momentwo.data.model.PresignedRequest
+import cord.eoeo.momentwo.data.model.PresignedUrl
 import retrofit2.http.Body
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.HTTP
 import retrofit2.http.Headers
-import retrofit2.http.Multipart
 import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -31,9 +32,14 @@ interface AlbumService {
         @Field("albumId") albumId: Int,
     )
 
-    @Multipart
     @Headers("content-type: application/json")
-    @PUT(MomentwoApi.PUT_ALBUM_IMAGE)
+    @POST(MomentwoApi.POST_ALBUM_PRESIGNED)
+    suspend fun postAlbumPresigned(
+        @Body presignedRequest: PresignedRequest
+    ): PresignedUrl
+
+    @Headers("content-type: application/json")
+    @POST(MomentwoApi.PUT_ALBUM_IMAGE)
     suspend fun putAlbumImage(
         @Body albumImage: AlbumImage,
     )

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
@@ -3,8 +3,6 @@ package cord.eoeo.momentwo.data.model
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import cord.eoeo.momentwo.ui.model.AlbumItem
-import okhttp3.MultipartBody
-import retrofit2.http.Part
 
 @JsonClass(generateAdapter = true)
 data class CreateAlbumInfo(
@@ -12,12 +10,13 @@ data class CreateAlbumInfo(
     val title: String,
     @Json(name = "doInviteNicknameList")
     val inviteList: List<String>,
+    val filename: String = "",
 )
 
 @JsonClass(generateAdapter = true)
 data class AlbumImage(
     val albumId: Int,
-    @Part val profileImage: MultipartBody.Part,
+    val filename: String,
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Photo.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Photo.kt
@@ -1,6 +1,5 @@
 package cord.eoeo.momentwo.data.model
 
-import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import cord.eoeo.momentwo.ui.model.ImageItem
 
@@ -8,8 +7,7 @@ import cord.eoeo.momentwo.ui.model.ImageItem
 data class UploadPhoto(
     val albumId: Int,
     val subAlbumId: Int,
-    @Json(name = "filename")
-    val imageUrl: String,
+    val filename: String,
 )
 
 @JsonClass(generateAdapter = true)
@@ -35,10 +33,4 @@ data class PhotoPage(
 data class PhotoInfo(
     val id: Int,
     val imageUrl: String
-) {
-    fun mapToImageItem(): ImageItem =
-        ImageItem(
-            id = id,
-            imageUrl = imageUrl,
-        )
-}
+)

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoDataSource.kt
@@ -11,7 +11,7 @@ import cord.eoeo.momentwo.data.photo.local.entity.PhotoRemoteKeyEntity
 
 interface PhotoDataSource {
     interface Remote {
-        suspend fun getPhotoPage(albumId: Int, subAlbumId: Int, cursor: Int): Result<PhotoPage>
+        suspend fun getPhotoPage(albumId: Int, subAlbumId: Int, pageSize: Int, cursor: Int): Result<PhotoPage>
 
         suspend fun requestPresignedUrl(presignedRequest: PresignedRequest): Result<PresignedUrl>
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoRemoteMediator.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoRemoteMediator.kt
@@ -13,7 +13,7 @@ class PhotoRemoteMediator(
     private val photoRemoteDataSource: PhotoDataSource.Remote,
     private val photoLocalDataSource: PhotoDataSource.Local,
 ) : RemoteMediator<Int, PhotoEntity>() {
-    private var pageSize = 50
+    private var pageSize = 20
     private var albumId = 0
     private var subAlbumId = 0
 
@@ -51,7 +51,7 @@ class PhotoRemoteMediator(
         }
 
         photoRemoteDataSource
-            .getPhotoPage(albumId, subAlbumId, (page ?: 0) * pageSize)
+            .getPhotoPage(albumId, subAlbumId, pageSize, (page ?: 0) * pageSize)
             .onSuccess { photoPage ->
                 if (loadType == LoadType.REFRESH) {
                     photoLocalDataSource.clearKeys()

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.Flow
 interface PhotoRepository {
     suspend fun getPhotoPagingData(pageSize: Int, albumId: Int, subAlbumId: Int): Flow<PagingData<ImageItem>>
 
-    suspend fun requestUploadPhoto(albumId: Int, subAlbumId: Int, mimeType: String, image: Uri): Result<Unit>
+    suspend fun requestUploadPhoto(albumId: Int, subAlbumId: Int, image: Uri): Result<Unit>
 
     suspend fun deletePhotos(albumId: Int, subAlbumId: Int, imageIds: List<Int>, imageUrls: List<String>): Result<Unit>
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoRemoteDataSource.kt
@@ -14,10 +14,10 @@ class PhotoRemoteDataSource(
     private val photoService: PhotoService,
     private val dispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : PhotoDataSource.Remote {
-    override suspend fun getPhotoPage(albumId: Int, subAlbumId: Int, cursor: Int): Result<PhotoPage> =
+    override suspend fun getPhotoPage(albumId: Int, subAlbumId: Int, pageSize: Int, cursor: Int): Result<PhotoPage> =
         runCatching {
             withContext(dispatcher) {
-                photoService.getPhotoPage(albumId, subAlbumId, cursor)
+                photoService.getPhotoPage(albumId, subAlbumId, pageSize, cursor)
             }
         }
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoService.kt
@@ -25,6 +25,7 @@ interface PhotoService {
     suspend fun getPhotoPage(
         @Path("albumId") albumId: Int,
         @Path("subAlbumId") subAlbumId: Int,
+        @Query("size") pageSize: Int,
         @Query("cursor") cursor: Int,
     ): PhotoPage
 

--- a/app/src/main/java/cord/eoeo/momentwo/di/AlbumModule.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/di/AlbumModule.kt
@@ -1,15 +1,18 @@
 package cord.eoeo.momentwo.di
 
+import android.content.Context
 import cord.eoeo.momentwo.data.album.AlbumDataSource
 import cord.eoeo.momentwo.data.album.AlbumRepositoryImpl
 import cord.eoeo.momentwo.data.album.remote.AlbumRemoteDataSource
 import cord.eoeo.momentwo.data.album.remote.AlbumService
+import cord.eoeo.momentwo.data.presigned.PresignedDataSource
 import cord.eoeo.momentwo.domain.album.AlbumRepository
 import cord.eoeo.momentwo.domain.album.GetAlbumListUseCase
 import cord.eoeo.momentwo.domain.album.RequestCreateAlbumUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import retrofit2.Retrofit
 import javax.inject.Singleton
@@ -27,7 +30,11 @@ object AlbumModule {
 
     @Provides
     @Singleton
-    fun provideAlbumRepository(albumRemoteDataSource: AlbumDataSource): AlbumRepository = AlbumRepositoryImpl(albumRemoteDataSource)
+    fun provideAlbumRepository(
+        albumRemoteDataSource: AlbumDataSource,
+        presignedRemoteDataSource: PresignedDataSource,
+        @ApplicationContext applicationContext: Context,
+    ): AlbumRepository = AlbumRepositoryImpl(albumRemoteDataSource, presignedRemoteDataSource, applicationContext)
 
     @Provides
     @Singleton
@@ -36,5 +43,6 @@ object AlbumModule {
 
     @Provides
     @Singleton
-    fun provideGetAlbumListUseCase(albumRepository: AlbumRepository): GetAlbumListUseCase = GetAlbumListUseCase(albumRepository)
+    fun provideGetAlbumListUseCase(albumRepository: AlbumRepository): GetAlbumListUseCase =
+        GetAlbumListUseCase(albumRepository)
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
@@ -319,6 +319,9 @@ constructor(
                             is AlbumDetailContract.AlbumSettingEvents.ChangeImage -> {
                                 albumRepository
                                     .changeAlbumImage(albumId, imageUri)
+                                    .onSuccess {
+                                        setEffect { AlbumDetailContract.Effect.PopBackStackInAlbumDetail }
+                                    }
                                     .onFailure { exception ->
                                         Log.e("AlbumDetail", "changeAlbumImage onFailure", exception)
                                     }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
@@ -81,7 +81,7 @@ fun ChangeImageScreen(
                     Text("이미지 선택")
                 }
 
-                Button(onClick = { /* TODO */ }) {
+                Button(onClick = onClickChange) {
                     Text("이미지 변경")
                 }
             }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
@@ -28,7 +28,7 @@ class PhotoListContract {
     ) : UiState
 
     sealed interface Event : UiEvent {
-        data class OnUploadImage(val imageUri: Uri, val mimeType: String) : Event
+        data class OnUploadImage(val imageUri: Uri) : Event
         data class OnChangeIsRefreshing(val isRefreshing: Boolean) : Event
         data class OnChangeIsMenuExpended(val isMenuExpended: Boolean) : Event
         data class OnChangeIsEditMode(val isEditMode: Boolean) : Event
@@ -37,11 +37,13 @@ class PhotoListContract {
         data class OnChangeIsSelected(val isSelected: Boolean, val imageItem: ImageItem) : Event
         data class OnChangeIsDialogOpened(val isDialogOpened: Boolean) : Event
         data class OnConfirmDialog(val subAlbumTitle: String) : Event
+        data object OnRefreshPagingData : Event
         data object OnBack : Event
         data class OnError(val errorMessage: String) : Event
     }
 
     sealed interface Effect : UiEffect {
+        data object RefreshPagingData : Effect
         data object PopBackStack : Effect
         data class ShowSnackbar(val message: String) : Effect
     }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListRoute.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
@@ -29,19 +28,13 @@ fun PhotoListRoute(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     viewModel: PhotoListViewModel = hiltViewModel(),
 ) {
-    val context = LocalContext.current
-    val contentResolver = context.contentResolver
-
     val uiState: PhotoListContract.State by viewModel.uiState.collectAsStateWithLifecycle()
     val refreshState: PullToRefreshState = rememberPullToRefreshState()
     val photoPagingData: LazyPagingItems<ImageItem> = uiState.photoPagingData.collectAsLazyPagingItems()
     val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         uri?.let { imageUri ->
             viewModel.setEvent(
-                PhotoListContract.Event.OnUploadImage(
-                    imageUri,
-                    contentResolver.getType(imageUri) ?: ""
-                )
+                PhotoListContract.Event.OnUploadImage(imageUri)
             )
         }
     }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
@@ -62,6 +62,10 @@ fun PhotoListScreen(
         effectFlow()
             .onEach { effect ->
                 when (effect) {
+                    is PhotoListContract.Effect.RefreshPagingData -> {
+                        photoPagingData().refresh()
+                    }
+
                     is PhotoListContract.Effect.PopBackStack -> {
                         popBackStack()
                     }
@@ -116,7 +120,7 @@ fun PhotoListScreen(
             onRefresh = {
                 onEvent(PhotoListContract.Event.OnChangeIsRefreshing(true))
                 coroutineScope.launch {
-                    photoPagingData().refresh()
+                    onEvent(PhotoListContract.Event.OnRefreshPagingData)
                     delay(500)
                     onEvent(PhotoListContract.Event.OnChangeIsRefreshing(false))
                 }


### PR DESCRIPTION
## PR 내용
### 앨범 이미지 업로드 수정
- Pre-Signed 적용
- 파일 → URL 전달로 변경
- 앨범 생성 시 빈 URL 전달 (data class 수정)

### CloudFront 적용 대응, 사진 목록 요청 수정
- 사진 업로드 파라미터 값 변경 (URL → Bucket 경로)
- mimeType Repository에서 가져와 전달하도록 변경
- 사진 목록 요청 - PageSize 추가
- 사진 업로드 후 자동 Refresh

Resolve: #79 