### PR TITLE
사진 Paging 요청 수정

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Photo.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Photo.kt
@@ -1,7 +1,6 @@
 package cord.eoeo.momentwo.data.model
 
 import com.squareup.moshi.JsonClass
-import cord.eoeo.momentwo.ui.model.ImageItem
 
 @JsonClass(generateAdapter = true)
 data class UploadPhoto(
@@ -21,12 +20,7 @@ data class DeletePhotos(
 @JsonClass(generateAdapter = true)
 data class PhotoPage(
     val images: List<PhotoInfo>,
-    val page: Int,
-    val size: Int,
-    val totalPages: Int,
-    val totalElements: Int,
-    val hasNext: Boolean,
-    val hasPrevious: Boolean,
+    val nextCursor: Int?,
 )
 
 @JsonClass(generateAdapter = true)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.itemKey
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.TextFieldDialog
@@ -128,15 +129,17 @@ fun PhotoListScreen(
             },
             modifier = Modifier
                 .fillMaxSize()
+                .padding(horizontal = 8.dp)
                 .padding(paddingValue),
         ) {
             LazyVerticalGrid(
                 columns = GridCells.Adaptive(100.dp),
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 8.dp),
+                modifier = Modifier.fillMaxSize(),
             ) {
-                items(count = photoPagingData().itemCount, key = { photoPagingData()[it]?.id ?: it }) { index ->
+                items(
+                    count = photoPagingData().itemCount,
+                    key = photoPagingData().itemKey { it.id },
+                ) { index ->
                     photoPagingData()[index]?.let { imageItem ->
                         PhotoListItemBox(
                             imageLoader = imageLoader,


### PR DESCRIPTION
## PR 내용
### 사진 Paging 요청 수정
- PhotoPage Data Type 수정 (nextCursor 추가, 불필요한 데이터 제거)
- PhotoRemoteMediator 수정
    - 1일 단위 자동 Refresh 구현
    - nextCursor를 이용하도록 수정
- LazyVerticalGrid key 수정 (PagingData itemKey 활용)

Resolve: #86 