### PR TITLE
사진 목록 화면 수정, 사진 디테일 화면으로 전달하는 정보 변경

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
@@ -48,6 +48,8 @@ object MomentwoApi {
     const val GET_PHOTO_PAGE = "/photos/view/{albumId}/{subAlbumId}"
     const val POST_PHOTO_PRESIGNED = "/images/photos/presigned"
     const val POST_PHOTO_UPLOAD = "/photos/upload"
+    /** Require @Query("subAlbumId"), @Query("minPid"), @Query("maxPid") */
+    const val GET_LIKED_PHOTOS = "/photo/likes/status/search"
 
     // Description
     const val POST_CREATE_DESCRIPTION = "/descriptions/create"

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Photo.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Photo.kt
@@ -28,3 +28,17 @@ data class PhotoInfo(
     val id: Int,
     val imageUrl: String
 )
+
+@JsonClass(generateAdapter = true)
+data class LikedPhotoList(
+    val likesList: List<LikedPhoto>
+)
+
+@JsonClass(generateAdapter = true)
+data class LikedPhoto(
+    val albumId: Int,
+    val subAlbumId: Int,
+    val photoId: Int,
+    val nickname: String,
+    val likesStatus: Boolean
+)

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoDataSource.kt
@@ -3,6 +3,7 @@ package cord.eoeo.momentwo.data.photo
 import android.graphics.Bitmap
 import androidx.paging.PagingSource
 import cord.eoeo.momentwo.data.model.DeletePhotos
+import cord.eoeo.momentwo.data.model.LikedPhotoList
 import cord.eoeo.momentwo.data.model.PhotoPage
 import cord.eoeo.momentwo.data.model.PresignedRequest
 import cord.eoeo.momentwo.data.model.PresignedUrl
@@ -20,14 +21,22 @@ interface PhotoDataSource {
         suspend fun requestUploadPhoto(uploadPhoto: UploadPhoto): Result<Unit>
 
         suspend fun deletePhotos(deletePhotos: DeletePhotos): Result<Unit>
+
+        suspend fun getLikedPhoto(subAlbumId: Int, minPid: Int, maxPid: Int): Result<LikedPhotoList>
     }
 
     interface Local {
         fun getPhotoPagingSource(albumId: Int, subAlbumId: Int): PagingSource<Int, PhotoEntity>
 
+        suspend fun getLastPhotoId(): Int?
+
         suspend fun insertPhotos(photos: List<PhotoEntity>)
 
-        suspend fun deletePhotos(photos: List<PhotoEntity>)
+        suspend fun deletePhotos(photoIds: List<Int>)
+
+        suspend fun deleteByRange(photoIds: List<Int>, start: Int, end: Int)
+
+        suspend fun updateIsLiked(photoId: Int, isLiked: Boolean)
 
         suspend fun downloadPhoto(bitmap: Bitmap, outputStream: OutputStream): Result<Unit>
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/local/PhotoDao.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/local/PhotoDao.kt
@@ -2,7 +2,6 @@ package cord.eoeo.momentwo.data.photo.local
 
 import androidx.paging.PagingSource
 import androidx.room.Dao
-import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
@@ -13,9 +12,18 @@ interface PhotoDao {
     @Query("SELECT * FROM photo WHERE album_id = :albumId AND sub_album_id = :subAlbumId ORDER BY id")
     fun getPhotoPagingSource(albumId: Int, subAlbumId: Int): PagingSource<Int, PhotoEntity>
 
+    @Query("SELECT id FROM photo ORDER BY id DESC LIMIT 1")
+    suspend fun getLastPhotoId(): Int?
+
+    @Query("UPDATE photo SET is_liked = :isLiked WHERE id = :photoId")
+    suspend fun updateIsLiked(photoId: Int, isLiked: Boolean)
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(vararg photos: PhotoEntity)
 
-    @Delete
-    suspend fun deleteAll(vararg photo: PhotoEntity)
+    @Query("DELETE FROM photo WHERE id IN (:photoIds)")
+    suspend fun deleteByIds(photoIds: List<Int>)
+
+    @Query("DELETE FROM photo WHERE id BETWEEN :start AND :end AND id NOT IN (:photoIds)")
+    suspend fun deleteByRange(photoIds: List<Int>, start: Int, end: Int)
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/local/PhotoLocalDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/local/PhotoLocalDataSource.kt
@@ -18,15 +18,32 @@ class PhotoLocalDataSource(
     override fun getPhotoPagingSource(albumId: Int, subAlbumId: Int): PagingSource<Int, PhotoEntity> =
         photoDao.getPhotoPagingSource(albumId, subAlbumId)
 
+    override suspend fun getLastPhotoId(): Int? =
+        withContext(dispatcher) {
+            photoDao.getLastPhotoId()
+        }
+
     override suspend fun insertPhotos(photos: List<PhotoEntity>) {
         withContext(dispatcher) {
             photoDao.insertAll(*photos.toTypedArray())
         }
     }
 
-    override suspend fun deletePhotos(photos: List<PhotoEntity>) {
+    override suspend fun deletePhotos(photoIds: List<Int>) {
         withContext(dispatcher) {
-            photoDao.deleteAll(*photos.toTypedArray())
+            photoDao.deleteByIds(photoIds)
+        }
+    }
+
+    override suspend fun deleteByRange(photoIds: List<Int>, start: Int, end: Int) {
+        withContext(dispatcher) {
+            photoDao.deleteByRange(photoIds, start, end)
+        }
+    }
+
+    override suspend fun updateIsLiked(photoId: Int, isLiked: Boolean) {
+        withContext(dispatcher) {
+            photoDao.updateIsLiked(photoId, isLiked)
         }
     }
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/local/entity/PhotoEntity.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/local/entity/PhotoEntity.kt
@@ -3,18 +3,20 @@ package cord.eoeo.momentwo.data.photo.local.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import cord.eoeo.momentwo.ui.model.ImageItem
+import cord.eoeo.momentwo.ui.model.PhotoItem
 
 @Entity(tableName = "photo")
 data class PhotoEntity(
     @PrimaryKey val id: Int,
     @ColumnInfo(name = "album_id") val albumId: Int,
     @ColumnInfo(name = "sub_album_id") val subAlbumId: Int,
-    @ColumnInfo(name = "image_url") val imageUrl: String,
+    @ColumnInfo(name = "photo_url") val photoUrl: String,
+    @ColumnInfo(name = "is_liked") val isLiked: Boolean,
 ) {
-    fun mapToImageItem(): ImageItem =
-        ImageItem(
+    fun mapToPhotoItem(): PhotoItem =
+        PhotoItem(
             id = id,
-            imageUrl = imageUrl,
+            photoUrl = photoUrl,
+            isLiked = isLiked,
         )
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoRemoteDataSource.kt
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.data.photo.remote
 
 import cord.eoeo.momentwo.data.model.DeletePhotos
+import cord.eoeo.momentwo.data.model.LikedPhotoList
 import cord.eoeo.momentwo.data.model.PhotoPage
 import cord.eoeo.momentwo.data.model.PresignedRequest
 import cord.eoeo.momentwo.data.model.PresignedUrl
@@ -39,6 +40,13 @@ class PhotoRemoteDataSource(
         runCatching {
             withContext(dispatcher) {
                 photoService.deletePhotos(deletePhotos)
+            }
+        }
+
+    override suspend fun getLikedPhoto(subAlbumId: Int, minPid: Int, maxPid: Int): Result<LikedPhotoList> =
+        runCatching {
+            withContext(dispatcher) {
+                photoService.getLikedPhotos(subAlbumId, minPid, maxPid)
             }
         }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoService.kt
@@ -2,6 +2,7 @@ package cord.eoeo.momentwo.data.photo.remote
 
 import cord.eoeo.momentwo.data.MomentwoApi
 import cord.eoeo.momentwo.data.model.DeletePhotos
+import cord.eoeo.momentwo.data.model.LikedPhotoList
 import cord.eoeo.momentwo.data.model.PhotoPage
 import cord.eoeo.momentwo.data.model.PresignedRequest
 import cord.eoeo.momentwo.data.model.PresignedUrl
@@ -40,4 +41,11 @@ interface PhotoService {
     suspend fun postPhotoUpload(
         @Body uploadPhoto: UploadPhoto
     )
+
+    @GET(MomentwoApi.GET_LIKED_PHOTOS)
+    suspend fun getLikedPhotos(
+        @Query("subAlbumId") subAlbumId: Int,
+        @Query("minPid") minPid: Int,
+        @Query("maxPid") maxPid: Int,
+    ): LikedPhotoList
 }

--- a/app/src/main/java/cord/eoeo/momentwo/di/PhotoModule.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/di/PhotoModule.kt
@@ -13,6 +13,7 @@ import cord.eoeo.momentwo.data.photo.remote.PhotoService
 import cord.eoeo.momentwo.data.presigned.PresignedDataSource
 import cord.eoeo.momentwo.domain.photo.DownloadPhotoUseCase
 import cord.eoeo.momentwo.domain.photo.PhotoRepository
+import cord.eoeo.momentwo.domain.photo.UpdateIsLikedUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -77,4 +78,9 @@ object PhotoModule {
     @Singleton
     fun provideDownloadPhotoUseCase(photoRepository: PhotoRepository): DownloadPhotoUseCase =
         DownloadPhotoUseCase(photoRepository)
+
+    @Provides
+    @Singleton
+    fun provideUpdateIsLikedUseCase(photoRepository: PhotoRepository): UpdateIsLikedUseCase =
+        UpdateIsLikedUseCase(photoRepository)
 }

--- a/app/src/main/java/cord/eoeo/momentwo/domain/photo/PhotoRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/photo/PhotoRepository.kt
@@ -2,15 +2,17 @@ package cord.eoeo.momentwo.domain.photo
 
 import android.net.Uri
 import androidx.paging.PagingData
-import cord.eoeo.momentwo.ui.model.ImageItem
+import cord.eoeo.momentwo.ui.model.PhotoItem
 import kotlinx.coroutines.flow.Flow
 
 interface PhotoRepository {
-    suspend fun getPhotoPagingData(pageSize: Int, albumId: Int, subAlbumId: Int): Flow<PagingData<ImageItem>>
+    suspend fun getPhotoPagingData(pageSize: Int, albumId: Int, subAlbumId: Int): Flow<PagingData<PhotoItem>>
 
     suspend fun requestUploadPhoto(albumId: Int, subAlbumId: Int, image: Uri): Result<Unit>
 
-    suspend fun deletePhotos(albumId: Int, subAlbumId: Int, imageIds: List<Int>, imageUrls: List<String>): Result<Unit>
+    suspend fun deletePhotos(albumId: Int, subAlbumId: Int, photoIds: List<Int>, photoUrls: List<String>): Result<Unit>
+
+    suspend fun updateIsLiked(photoId: Int, isLiked: Boolean)
 
     suspend fun downloadPhoto(imageUrl: String): Result<Unit>
 }

--- a/app/src/main/java/cord/eoeo/momentwo/domain/photo/UpdateIsLikedUseCase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/photo/UpdateIsLikedUseCase.kt
@@ -1,0 +1,6 @@
+package cord.eoeo.momentwo.domain.photo
+
+class UpdateIsLikedUseCase(private val photoRepository: PhotoRepository) {
+    suspend operator fun invoke(photoId: Int, isLiked: Boolean) =
+        photoRepository.updateIsLiked(photoId, isLiked)
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
@@ -33,9 +33,9 @@ sealed interface MomentwoDestination {
     @Serializable
     data class PhotoDetail(
         val albumId: Int,
-        val subAlbumId: Int,
         val photoId: Int,
         val photoUrl: String,
+        val isLiked: Boolean,
     )
 
     @Serializable
@@ -70,8 +70,8 @@ class MomentwoNavigationActions(navController: NavHostController) {
     val navigateToPhotoList: (Int, Int, String, String) -> Unit = { albumId, subAlbumId, albumTitle, subAlbumTitle ->
         navController.navigate(MomentwoDestination.PhotoList(albumId, subAlbumId, albumTitle, subAlbumTitle))
     }
-    val navigateToPhotoDetail: (Int, Int, Int, String) -> Unit = { albumId, subAlbumId, photoId, photoUrl ->
-        navController.navigate(MomentwoDestination.PhotoDetail(albumId, subAlbumId, photoId, photoUrl))
+    val navigateToPhotoDetail: (Int, Int, String, Boolean) -> Unit = { albumId, photoId, photoUrl, isLiked ->
+        navController.navigate(MomentwoDestination.PhotoDetail(albumId, photoId, photoUrl, isLiked))
     }
     val navigateToCreateAlbum: () -> Unit = {
         navController.navigate(MomentwoDestination.CreateAlbum)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/model/PhotoItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/model/PhotoItem.kt
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.ui.model
+
+data class PhotoItem(
+    val id: Int,
+    val photoUrl: String,
+    val isLiked: Boolean,
+)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailContract.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.emptyFlow
 class PhotoDetailContract {
     data class State(
         val albumId: Int = -1,
-        val subAlbumId: Int = -1,
         val photoId: Int = -1,
         val photoUrl: String = "",
         val descriptionItem: DescriptionItem = DescriptionItem("", "", "", ""),

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
@@ -6,6 +6,7 @@ import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
 import cord.eoeo.momentwo.ui.model.ImageItem
+import cord.eoeo.momentwo.ui.model.PhotoItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
@@ -15,7 +16,7 @@ class PhotoListContract {
         val subAlbumId: Int = -1,
         val albumTitle: String = "",
         val subAlbumTitle: String = "",
-        val photoPagingData: Flow<PagingData<ImageItem>> = emptyFlow(),
+        val photoPagingData: Flow<PagingData<PhotoItem>> = emptyFlow(),
         val selectedPhotoIds: List<Int> = emptyList(),
         val selectedPhotoUrls: List<String> = emptyList(),
         val isMenuExpended: Boolean = false,
@@ -34,7 +35,7 @@ class PhotoListContract {
         data class OnChangeIsEditMode(val isEditMode: Boolean) : Event
         data object OnClickCancelEdit : Event
         data object OnClickConfirmEdit : Event
-        data class OnChangeIsSelected(val isSelected: Boolean, val imageItem: ImageItem) : Event
+        data class OnChangeIsSelected(val isSelected: Boolean, val photoItem: PhotoItem) : Event
         data class OnChangeIsDialogOpened(val isDialogOpened: Boolean) : Event
         data class OnConfirmDialog(val subAlbumTitle: String) : Event
         data object OnRefreshPagingData : Event

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListItemBox.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListItemBox.kt
@@ -7,9 +7,14 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CheckboxDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -19,19 +24,22 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImage
-import cord.eoeo.momentwo.ui.model.ImageItem
+import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.ui.theme.favoriteBorder
+import cord.eoeo.momentwo.ui.theme.primaryDark
 
 @Composable
 fun PhotoListItemBox(
     imageLoader: ImageLoader,
-    imageItem: () -> ImageItem,
+    photoItem: () -> PhotoItem,
     isEditMode: () -> Boolean,
     isSelected: () -> Boolean,
     onChangeSelected: (Boolean) -> Unit,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .aspectRatio(1f)
             .padding(4.dp)
@@ -44,7 +52,7 @@ fun PhotoListItemBox(
             },
     ) {
         AsyncImage(
-            model = imageItem().imageUrl,
+            model = photoItem().photoUrl,
             contentDescription = "사진",
             imageLoader = imageLoader,
             contentScale = ContentScale.Crop,
@@ -52,6 +60,28 @@ fun PhotoListItemBox(
                 .fillMaxSize()
                 .clip(RoundedCornerShape(4.dp)),
         )
+
+        if (photoItem().isLiked) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(8.dp),
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Favorite,
+                    contentDescription = "",
+                    tint = primaryDark,
+                    modifier = Modifier.size(20.dp)
+                )
+
+                Icon(
+                    imageVector = Icons.Outlined.FavoriteBorder,
+                    contentDescription = "",
+                    tint = favoriteBorder,
+                    modifier = Modifier.size(20.dp)
+                )
+            }
+        }
 
         if (isEditMode()) {
             if (isSelected()) {

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListRoute.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.model.ImageItem
+import cord.eoeo.momentwo.ui.model.PhotoItem
 import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -24,14 +24,14 @@ fun PhotoListRoute(
     coroutineScope: CoroutineScope,
     imageLoader: ImageLoader,
     popBackStack: () -> Unit,
-    navigateToPhotoDetail: (Int, Int, Int, String) -> Unit,
+    navigateToPhotoDetail: (Int, Int, String, Boolean) -> Unit,
     modifier: Modifier = Modifier,
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     viewModel: PhotoListViewModel = hiltViewModel(),
 ) {
     val uiState: PhotoListContract.State by viewModel.uiState.collectAsStateWithLifecycle()
     val refreshState: PullToRefreshState = rememberPullToRefreshState()
-    val photoPagingData: LazyPagingItems<ImageItem> = uiState.photoPagingData.collectAsLazyPagingItems()
+    val photoPagingData: LazyPagingItems<PhotoItem> = uiState.photoPagingData.collectAsLazyPagingItems()
     val galleryLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         uri?.let { imageUri ->
             viewModel.setEvent(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
@@ -36,7 +36,7 @@ import androidx.paging.compose.itemKey
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.TextFieldDialog
-import cord.eoeo.momentwo.ui.model.ImageItem
+import cord.eoeo.momentwo.ui.model.PhotoItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -53,11 +53,11 @@ fun PhotoListScreen(
     effectFlow: () -> Flow<PhotoListContract.Effect>,
     onEvent: (event: PhotoListContract.Event) -> Unit,
     refreshState: () -> PullToRefreshState,
-    photoPagingData: () -> LazyPagingItems<ImageItem>,
+    photoPagingData: () -> LazyPagingItems<PhotoItem>,
     launchGallery: () -> Unit,
     snackbarHostState: () -> SnackbarHostState,
     popBackStack: () -> Unit,
-    navigateToPhotoDetail: (Int, Int, Int, String) -> Unit,
+    navigateToPhotoDetail: (Int, Int, String, Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(SIDE_EFFECTS_KEY) {
@@ -140,23 +140,24 @@ fun PhotoListScreen(
                     count = photoPagingData().itemCount,
                     key = photoPagingData().itemKey { it.id },
                 ) { index ->
-                    photoPagingData()[index]?.let { imageItem ->
+                    photoPagingData()[index]?.let { photoItem ->
                         PhotoListItemBox(
                             imageLoader = imageLoader,
-                            imageItem = { imageItem },
+                            photoItem = { photoItem },
                             isEditMode = { uiState().isEditMode },
-                            isSelected = { uiState().selectedPhotoIds.contains(imageItem.id) },
+                            isSelected = { uiState().selectedPhotoIds.contains(photoItem.id) },
                             onChangeSelected = { isSelected ->
-                                onEvent(PhotoListContract.Event.OnChangeIsSelected(isSelected, imageItem))
+                                onEvent(PhotoListContract.Event.OnChangeIsSelected(isSelected, photoItem))
                             },
                             onClick = {
                                 navigateToPhotoDetail(
                                     uiState().albumId,
-                                    uiState().subAlbumId,
-                                    imageItem.id,
-                                    imageItem.imageUrl,
+                                    photoItem.id,
+                                    photoItem.photoUrl,
+                                    photoItem.isLiked,
                                 )
                             },
+                            modifier = Modifier.animateItem(),
                         )
                     }
                 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListViewModel.kt
@@ -93,7 +93,6 @@ class PhotoListViewModel @Inject constructor(
                                         selectedPhotoUrls = emptyList(),
                                     )
                                 )
-                                setEffect { PhotoListContract.Effect.RefreshPagingData }
                             }.onFailure {
                                 /* TODO: 삭제 실패 */
                                 Log.e("Photo", "deletePhotos Failure", it)
@@ -109,11 +108,11 @@ class PhotoListViewModel @Inject constructor(
                         val newSelectedUrls = selectedPhotoUrls.toMutableList()
 
                         if (newEvent.isSelected) {
-                            newSelectedIds.add(newEvent.imageItem.id)
-                            newSelectedUrls.add(newEvent.imageItem.imageUrl)
+                            newSelectedIds.add(newEvent.photoItem.id)
+                            newSelectedUrls.add(newEvent.photoItem.photoUrl)
                         } else {
-                            newSelectedIds.remove(newEvent.imageItem.id)
-                            newSelectedUrls.remove(newEvent.imageItem.imageUrl)
+                            newSelectedIds.remove(newEvent.photoItem.id)
+                            newSelectedUrls.remove(newEvent.photoItem.photoUrl)
                         }
 
                         setState(copy(selectedPhotoIds = newSelectedIds, selectedPhotoUrls = newSelectedUrls))

--- a/app/src/main/java/cord/eoeo/momentwo/ui/theme/Color.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/theme/Color.kt
@@ -6,6 +6,7 @@ val white = Color(0xFFFFFFFF)
 val black = Color(0xFF000000)
 val darkGray = Color(0xFF43474E)
 val starYellow = Color(0xFFF5B700)
+val favoriteBorder = Color(0xFFD9DAE1)
 
 val primaryLight = Color(0xFF3A608F)
 val onPrimaryLight = white


### PR DESCRIPTION
## PR 내용
### 사진 목록 화면 수정, 사진 디테일 화면으로 정보 전달
- 사진 페이지 요청 시 좋아요 정보 요청
    - PhotoEntity 에 isLiked 추가
- 사진 목록 화면 수정
    - 사진 ItemBox 에 isLiked 정보 표시
- 사진 디테일 화면 subAlbumId 삭제, isLiked 추가
- 사진 디테일 화면에서 좋아요 정보 변경했을 때 사진 목록 화면에 반영
    - 캐싱된 Local DB 정보 변경으로 반영
- 다른 이용자가 사진을 삭제했을 때 Refresh로 반영되도록 수정
    - PhotoPage 요청 후 처음, 끝 photoId 값을 이용해 삭제된 사진 Local DB에서 삭제
    - DB에 저장된 마지막 사진(photoId 값이 가장 큰 사진)이 삭제된 경우 예외처리 수행

Resolve: #96 