### PR TITLE
유저 프로필 요청 기능 구현

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/MomentwoApi.kt
@@ -13,6 +13,10 @@ object MomentwoApi {
     // Login
     const val POST_LOGIN = "/signin"
 
+    // Profile
+    /** Require @Query("nickname") */
+    const val GET_PROFILE = "/users/profiles"
+
     // Album
     const val POST_CREATE_ALBUM = "/albums"
     /** Require @Path("albumId") */

--- a/app/src/main/java/cord/eoeo/momentwo/data/MomentwoDatabase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/MomentwoDatabase.kt
@@ -6,6 +6,8 @@ import cord.eoeo.momentwo.data.friend.local.FriendDao
 import cord.eoeo.momentwo.data.friend.local.FriendRemoteKeyDao
 import cord.eoeo.momentwo.data.friend.local.entity.FriendEntity
 import cord.eoeo.momentwo.data.friend.local.entity.FriendRemoteKeyEntity
+import cord.eoeo.momentwo.data.profile.local.ProfileDao
+import cord.eoeo.momentwo.data.profile.local.entity.ProfileEntity
 import cord.eoeo.momentwo.data.photo.local.PhotoDao
 import cord.eoeo.momentwo.data.photo.local.PhotoRemoteKeyDao
 import cord.eoeo.momentwo.data.photo.local.entity.PhotoEntity
@@ -17,8 +19,9 @@ import cord.eoeo.momentwo.data.photo.local.entity.PhotoRemoteKeyEntity
         PhotoRemoteKeyEntity::class,
         FriendEntity::class,
         FriendRemoteKeyEntity::class,
+        ProfileEntity::class,
     ],
-    version = 2
+    version = 1,
 )
 abstract class MomentwoDatabase : RoomDatabase() {
     abstract fun photoDao(): PhotoDao
@@ -28,4 +31,6 @@ abstract class MomentwoDatabase : RoomDatabase() {
     abstract fun friendDao(): FriendDao
 
     abstract fun friendRemoteKeyDao(): FriendRemoteKeyDao
+
+    abstract fun profileDao(): ProfileDao
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/login/LoginDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/login/LoginDataSource.kt
@@ -1,8 +1,9 @@
 package cord.eoeo.momentwo.data.login
 
 import cord.eoeo.momentwo.data.model.LoginRequest
+import cord.eoeo.momentwo.data.model.UserProfile
 import retrofit2.Response
 
 interface LoginDataSource {
-    suspend fun requestLogin(loginData: LoginRequest): Response<Unit>
+    suspend fun requestLogin(loginData: LoginRequest): Response<UserProfile>
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/login/LoginRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/login/LoginRepository.kt
@@ -1,7 +1,0 @@
-package cord.eoeo.momentwo.data.login
-
-import cord.eoeo.momentwo.ui.model.TokenItem
-
-interface LoginRepository {
-    suspend fun requestLogin(email: String, password: String): Result<TokenItem>
-}

--- a/app/src/main/java/cord/eoeo/momentwo/data/login/remote/LoginRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/login/remote/LoginRemoteDataSource.kt
@@ -2,6 +2,7 @@ package cord.eoeo.momentwo.data.login.remote
 
 import cord.eoeo.momentwo.data.login.LoginDataSource
 import cord.eoeo.momentwo.data.model.LoginRequest
+import cord.eoeo.momentwo.data.model.UserProfile
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -9,9 +10,9 @@ import retrofit2.Response
 
 class LoginRemoteDataSource(
     private val loginService: LoginService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : LoginDataSource {
-    override suspend fun requestLogin(loginData: LoginRequest): Response<Unit> =
+    override suspend fun requestLogin(loginData: LoginRequest): Response<UserProfile> =
         withContext(dispatcher) {
             loginService.postLogin(loginData)
         }

--- a/app/src/main/java/cord/eoeo/momentwo/data/login/remote/LoginService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/login/remote/LoginService.kt
@@ -2,6 +2,7 @@ package cord.eoeo.momentwo.data.login.remote
 
 import cord.eoeo.momentwo.data.MomentwoApi
 import cord.eoeo.momentwo.data.model.LoginRequest
+import cord.eoeo.momentwo.data.model.UserProfile
 import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.Headers
@@ -12,5 +13,5 @@ interface LoginService {
     @POST(MomentwoApi.POST_LOGIN)
     suspend fun postLogin(
         @Body loginData: LoginRequest,
-    ): Response<Unit>
+    ): Response<UserProfile>
 }

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/User.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/User.kt
@@ -11,3 +11,12 @@ data class User(
     val birthday: String,
     val phone: String,
 )
+
+@JsonClass(generateAdapter = true)
+data class UserProfile(
+    val name: String,
+    val username: String,
+    val nickname: String,
+    val phone: String,
+    val userProfileImage: String,
+)

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/ProfileDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/ProfileDataSource.kt
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.data.profile
+
+import cord.eoeo.momentwo.data.model.UserProfile
+import cord.eoeo.momentwo.data.profile.local.entity.ProfileEntity
+
+interface ProfileDataSource {
+    interface Local {
+        suspend fun storeProfile(profile: ProfileEntity): Result<Unit>
+
+        suspend fun getProfile(): Result<ProfileEntity>
+    }
+
+    interface Remote {
+        suspend fun getProfile(nickname: String): Result<UserProfile>
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/ProfileRepositoryImpl.kt
@@ -1,0 +1,25 @@
+package cord.eoeo.momentwo.data.profile
+
+import cord.eoeo.momentwo.domain.mapper.ProfileMapper
+import cord.eoeo.momentwo.domain.model.Profile
+import cord.eoeo.momentwo.domain.profile.ProfileRepository
+
+class ProfileRepositoryImpl(
+    private val profileLocalDataSource: ProfileDataSource.Local,
+    private val profileRemoteDataSource: ProfileDataSource.Remote,
+    private val profileMapper: ProfileMapper,
+) : ProfileRepository {
+    override suspend fun storeProfile(profile: Profile): Result<Unit> =
+        profileLocalDataSource.storeProfile(profileMapper.domainToEntity(profile))
+
+    override suspend fun getProfile(nickname: String?): Result<Profile> =
+        if (nickname.isNullOrEmpty()) {
+            profileLocalDataSource.getProfile().map { profileEntity ->
+                profileMapper.entityToDomain(profileEntity)
+            }
+        } else {
+            profileRemoteDataSource.getProfile(nickname).map { userProfile ->
+                profileMapper.dataToDomain(userProfile)
+            }
+        }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/local/ProfileDao.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/local/ProfileDao.kt
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.data.profile.local
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import cord.eoeo.momentwo.data.profile.local.entity.ProfileEntity
+
+@Dao
+interface ProfileDao {
+    @Query("SELECT * FROM profile LIMIT 1")
+    suspend fun getProfile(): ProfileEntity
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertUser(profile: ProfileEntity)
+}

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/local/ProfileLocalDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/local/ProfileLocalDataSource.kt
@@ -1,0 +1,26 @@
+package cord.eoeo.momentwo.data.profile.local
+
+import cord.eoeo.momentwo.data.profile.ProfileDataSource
+import cord.eoeo.momentwo.data.profile.local.entity.ProfileEntity
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ProfileLocalDataSource(
+    private val profileDao: ProfileDao,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ProfileDataSource.Local {
+    override suspend fun storeProfile(profile: ProfileEntity): Result<Unit> =
+        runCatching {
+            withContext(dispatcher) {
+                profileDao.insertUser(profile)
+            }
+        }
+
+    override suspend fun getProfile(): Result<ProfileEntity> =
+        runCatching {
+            withContext(dispatcher) {
+                profileDao.getProfile()
+            }
+        }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/local/entity/ProfileEntity.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/local/entity/ProfileEntity.kt
@@ -1,0 +1,14 @@
+package cord.eoeo.momentwo.data.profile.local.entity
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "profile")
+data class ProfileEntity(
+    @PrimaryKey val username: String,
+    val name: String,
+    val nickname: String,
+    val phone: String,
+    @ColumnInfo(name = "user_profile_image") val userProfileImage: String,
+)

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/remote/ProfileRemoteDataSource.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/remote/ProfileRemoteDataSource.kt
@@ -1,0 +1,19 @@
+package cord.eoeo.momentwo.data.profile.remote
+
+import cord.eoeo.momentwo.data.model.UserProfile
+import cord.eoeo.momentwo.data.profile.ProfileDataSource
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class ProfileRemoteDataSource(
+    private val profileService: ProfileService,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : ProfileDataSource.Remote {
+    override suspend fun getProfile(nickname: String): Result<UserProfile> =
+        runCatching {
+            withContext(dispatcher) {
+                profileService.getProfile(nickname)
+            }
+        }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/remote/ProfileService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/remote/ProfileService.kt
@@ -1,0 +1,13 @@
+package cord.eoeo.momentwo.data.profile.remote
+
+import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.data.model.UserProfile
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface ProfileService {
+    @GET(MomentwoApi.GET_PROFILE)
+    suspend fun getProfile(
+        @Query("nickname") nickname: String,
+    ): UserProfile
+}

--- a/app/src/main/java/cord/eoeo/momentwo/di/LoginModule.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/di/LoginModule.kt
@@ -1,10 +1,15 @@
 package cord.eoeo.momentwo.di
 
+import cord.eoeo.momentwo.data.authentication.PreferenceRepository
 import cord.eoeo.momentwo.data.login.LoginDataSource
-import cord.eoeo.momentwo.data.login.LoginRepository
 import cord.eoeo.momentwo.data.login.LoginRepositoryImpl
 import cord.eoeo.momentwo.data.login.remote.LoginRemoteDataSource
 import cord.eoeo.momentwo.data.login.remote.LoginService
+import cord.eoeo.momentwo.domain.login.LoginRepository
+import cord.eoeo.momentwo.domain.login.RequestLoginUseCase
+import cord.eoeo.momentwo.domain.login.TryAutoLoginUseCase
+import cord.eoeo.momentwo.domain.mapper.ProfileMapper
+import cord.eoeo.momentwo.domain.profile.ProfileRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,16 +22,29 @@ import javax.inject.Singleton
 object LoginModule {
     @Provides
     @Singleton
-    fun provideLoginService(retrofit: Retrofit) =
-        retrofit.create(LoginService::class.java)
+    fun provideLoginService(retrofit: Retrofit) = retrofit.create(LoginService::class.java)
 
     @Provides
     @Singleton
-    fun provideLoginRemoteDataSource(loginService: LoginService): LoginDataSource =
-        LoginRemoteDataSource(loginService)
+    fun provideLoginRemoteDataSource(loginService: LoginService): LoginDataSource = LoginRemoteDataSource(loginService)
 
     @Provides
     @Singleton
-    fun provideLoginRepository(loginRemoteDataSource: LoginDataSource): LoginRepository =
-        LoginRepositoryImpl(loginRemoteDataSource)
+    fun provideLoginRepository(
+        loginRemoteDataSource: LoginDataSource,
+        profileMapper: ProfileMapper,
+    ): LoginRepository = LoginRepositoryImpl(loginRemoteDataSource, profileMapper)
+
+    @Provides
+    @Singleton
+    fun provideRequestLoginUseCase(
+        loginRepository: LoginRepository,
+        profileRepository: ProfileRepository,
+        preferenceRepository: PreferenceRepository,
+    ): RequestLoginUseCase = RequestLoginUseCase(loginRepository, profileRepository, preferenceRepository)
+
+    @Provides
+    @Singleton
+    fun provideTryAutoLoginUseCase(preferenceRepository: PreferenceRepository): TryAutoLoginUseCase =
+        TryAutoLoginUseCase(preferenceRepository)
 }

--- a/app/src/main/java/cord/eoeo/momentwo/di/ProfileModule.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/di/ProfileModule.kt
@@ -1,0 +1,47 @@
+package cord.eoeo.momentwo.di
+
+import cord.eoeo.momentwo.data.MomentwoDatabase
+import cord.eoeo.momentwo.data.profile.ProfileDataSource
+import cord.eoeo.momentwo.data.profile.ProfileRepositoryImpl
+import cord.eoeo.momentwo.data.profile.local.ProfileDao
+import cord.eoeo.momentwo.data.profile.local.ProfileLocalDataSource
+import cord.eoeo.momentwo.data.profile.remote.ProfileRemoteDataSource
+import cord.eoeo.momentwo.data.profile.remote.ProfileService
+import cord.eoeo.momentwo.domain.mapper.ProfileMapper
+import cord.eoeo.momentwo.domain.profile.ProfileRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import retrofit2.Retrofit
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object ProfileModule {
+    @Provides
+    @Singleton
+    fun provideProfileDao(database: MomentwoDatabase): ProfileDao = database.profileDao()
+
+    @Provides
+    @Singleton
+    fun provideProfileService(retrofit: Retrofit) = retrofit.create(ProfileService::class.java)
+
+    @Provides
+    @Singleton
+    @QualifierModule.LocalDataSource
+    fun provideProfileLocalDataSource(profileDao: ProfileDao): ProfileDataSource.Local = ProfileLocalDataSource(profileDao)
+
+    @Provides
+    @Singleton
+    @QualifierModule.RemoteDataSource
+    fun provideProfileRemoteDataSource(profileService: ProfileService): ProfileDataSource.Remote = ProfileRemoteDataSource(profileService)
+
+    @Provides
+    @Singleton
+    fun provideProfileRepository(
+        @QualifierModule.LocalDataSource profileLocalDataSource: ProfileDataSource.Local,
+        @QualifierModule.RemoteDataSource profileRemoteDataSource: ProfileDataSource.Remote,
+        profileMapper: ProfileMapper,
+    ): ProfileRepository = ProfileRepositoryImpl(profileLocalDataSource, profileRemoteDataSource, profileMapper)
+}

--- a/app/src/main/java/cord/eoeo/momentwo/domain/login/LoginRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/login/LoginRepository.kt
@@ -1,0 +1,10 @@
+package cord.eoeo.momentwo.domain.login
+
+import cord.eoeo.momentwo.domain.model.LoginData
+
+interface LoginRepository {
+    suspend fun requestLogin(
+        email: String,
+        password: String,
+    ): Result<LoginData>
+}

--- a/app/src/main/java/cord/eoeo/momentwo/domain/login/RequestLoginUseCase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/login/RequestLoginUseCase.kt
@@ -1,0 +1,22 @@
+package cord.eoeo.momentwo.domain.login
+
+import cord.eoeo.momentwo.data.authentication.PreferenceRepository
+import cord.eoeo.momentwo.domain.profile.ProfileRepository
+
+class RequestLoginUseCase(
+    private val loginRepository: LoginRepository,
+    private val profileRepository: ProfileRepository,
+    private val preferenceRepository: PreferenceRepository,
+) {
+    suspend operator fun invoke(
+        email: String,
+        password: String,
+    ): Result<Unit> =
+        runCatching {
+            val loginData = loginRepository.requestLogin(email, password).getOrThrow()
+
+            preferenceRepository.storeAccessToken(loginData.accessToken)
+            preferenceRepository.storeRefreshToken(loginData.refreshToken)
+            profileRepository.storeProfile(loginData.profile)
+        }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/domain/login/TryAutoLoginUseCase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/login/TryAutoLoginUseCase.kt
@@ -1,0 +1,16 @@
+package cord.eoeo.momentwo.domain.login
+
+import cord.eoeo.momentwo.data.authentication.PreferenceRepository
+
+class TryAutoLoginUseCase(
+    private val preferenceRepository: PreferenceRepository,
+) {
+    suspend operator fun invoke(): Result<Unit> =
+        runCatching {
+            val accessToken = preferenceRepository.getAccessToken().getOrThrow()
+
+            if (accessToken.isEmpty()) throw Exception("AutoLogin: No login history")
+
+            Result.success(Unit)
+        }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/domain/mapper/ProfileMapper.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/mapper/ProfileMapper.kt
@@ -1,0 +1,47 @@
+package cord.eoeo.momentwo.domain.mapper
+
+import cord.eoeo.momentwo.data.model.UserProfile
+import cord.eoeo.momentwo.data.profile.local.entity.ProfileEntity
+import cord.eoeo.momentwo.domain.model.Profile
+import cord.eoeo.momentwo.ui.model.ProfileItem
+import javax.inject.Inject
+
+class ProfileMapper
+    @Inject
+    constructor() {
+        fun entityToDomain(profileEntity: ProfileEntity): Profile =
+            Profile(
+                name = profileEntity.name,
+                email = profileEntity.username,
+                nickname = profileEntity.nickname,
+                phone = profileEntity.phone,
+                profileImage = profileEntity.userProfileImage,
+            )
+
+        fun domainToEntity(profile: Profile): ProfileEntity =
+            ProfileEntity(
+                username = profile.email,
+                name = profile.name,
+                nickname = profile.nickname,
+                phone = profile.phone,
+                userProfileImage = profile.profileImage,
+            )
+
+        fun dataToDomain(userProfile: UserProfile): Profile =
+            Profile(
+                name = userProfile.name,
+                email = userProfile.username,
+                nickname = userProfile.nickname,
+                phone = userProfile.phone,
+                profileImage = userProfile.userProfileImage,
+            )
+
+        fun domainToUI(profile: Profile): ProfileItem =
+            ProfileItem(
+                name = profile.name,
+                email = profile.email,
+                nickname = profile.nickname,
+                phone = profile.phone,
+                profileImage = profile.profileImage,
+            )
+    }

--- a/app/src/main/java/cord/eoeo/momentwo/domain/model/LoginData.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/model/LoginData.kt
@@ -1,0 +1,7 @@
+package cord.eoeo.momentwo.domain.model
+
+data class LoginData(
+    val accessToken: String,
+    val refreshToken: String,
+    val profile: Profile,
+)

--- a/app/src/main/java/cord/eoeo/momentwo/domain/model/Profile.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/model/Profile.kt
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.domain.model
+
+data class Profile(
+    val name: String,
+    val email: String,
+    val nickname: String,
+    val phone: String,
+    val profileImage: String,
+)

--- a/app/src/main/java/cord/eoeo/momentwo/domain/profile/ProfileRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/profile/ProfileRepository.kt
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.domain.profile
+
+import cord.eoeo.momentwo.domain.model.Profile
+
+interface ProfileRepository {
+    suspend fun storeProfile(profile: Profile): Result<Unit>
+
+    suspend fun getProfile(nickname: String?): Result<Profile>
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavGraph.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavGraph.kt
@@ -14,6 +14,7 @@ import cord.eoeo.momentwo.ui.friend.FriendRoute
 import cord.eoeo.momentwo.ui.login.LoginRoute
 import cord.eoeo.momentwo.ui.photodetail.PhotoDetailRoute
 import cord.eoeo.momentwo.ui.photolist.PhotoListRoute
+import cord.eoeo.momentwo.ui.profile.ProfileRoute
 import cord.eoeo.momentwo.ui.signup.SignUpRoute
 import kotlinx.coroutines.CoroutineScope
 
@@ -51,6 +52,7 @@ fun MomentwoNavGraph(
                 coroutineScope = coroutineScope,
                 navigateToCreateAlbum = navActions.navigateToCreateAlbum,
                 navigateToFriend = navActions.navigateToFriend,
+                navigateToProfile = { navActions.navigateToProfile(null) },
                 navigateToAlbumDetail = navActions.navigateToAlbumDetail,
                 imageLoader = imageLoader,
             )
@@ -61,7 +63,7 @@ fun MomentwoNavGraph(
                 coroutineScope = coroutineScope,
                 imageLoader = imageLoader,
                 popBackStack = navActions.popBackStack,
-                navigateToPhotoList = navActions.navigateToPhotoList
+                navigateToPhotoList = navActions.navigateToPhotoList,
             )
         }
 
@@ -70,7 +72,7 @@ fun MomentwoNavGraph(
                 coroutineScope = coroutineScope,
                 imageLoader = imageLoader,
                 popBackStack = navActions.popBackStack,
-                navigateToPhotoDetail = navActions.navigateToPhotoDetail
+                navigateToPhotoDetail = navActions.navigateToPhotoDetail,
             )
         }
 
@@ -87,6 +89,14 @@ fun MomentwoNavGraph(
             CreateAlbumRoute(
                 coroutineScope = coroutineScope,
                 popBackStack = navActions.popBackStack,
+            )
+        }
+
+        composable<MomentwoDestination.Profile> {
+            ProfileRoute(
+                coroutineScope = coroutineScope,
+                popBackStack = navActions.popBackStack,
+                imageLoader = imageLoader,
             )
         }
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
@@ -20,7 +20,7 @@ sealed interface MomentwoDestination {
         val title: String,
         val subTitle: String,
         val imageUrl: String,
-    )
+    ) : MomentwoDestination
 
     @Serializable
     data class PhotoList(
@@ -36,16 +36,23 @@ sealed interface MomentwoDestination {
         val photoId: Int,
         val photoUrl: String,
         val isLiked: Boolean,
-    )
+    ) : MomentwoDestination
 
     @Serializable
     data object CreateAlbum : MomentwoDestination
 
     @Serializable
+    data class Profile(
+        val nickname: String?,
+    ) : MomentwoDestination
+
+    @Serializable
     data object Friend : MomentwoDestination
 }
 
-class MomentwoNavigationActions(navController: NavHostController) {
+class MomentwoNavigationActions(
+    navController: NavHostController,
+) {
     val popBackStack: () -> Unit = {
         navController.popBackStack()
     }
@@ -75,6 +82,9 @@ class MomentwoNavigationActions(navController: NavHostController) {
     }
     val navigateToCreateAlbum: () -> Unit = {
         navController.navigate(MomentwoDestination.CreateAlbum)
+    }
+    val navigateToProfile: (String?) -> Unit = { nickname ->
+        navController.navigate(MomentwoDestination.Profile(nickname))
     }
     val navigateToFriend: () -> Unit = {
         navController.navigate(MomentwoDestination.Friend)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumRoute.kt
@@ -20,6 +20,7 @@ fun AlbumRoute(
     coroutineScope: CoroutineScope,
     imageLoader: ImageLoader,
     navigateToCreateAlbum: () -> Unit,
+    navigateToProfile: () -> Unit,
     navigateToFriend: () -> Unit,
     navigateToAlbumDetail: (AlbumItem) -> Unit,
     modifier: Modifier = Modifier,
@@ -40,6 +41,7 @@ fun AlbumRoute(
         onClickDrawer = { coroutineScope.launch { drawerState.open() } },
         onCloseDrawer = { coroutineScope.launch { drawerState.close() } },
         navigateToCreateAlbum = navigateToCreateAlbum,
+        navigateToProfile = navigateToProfile,
         navigateToFriend = navigateToFriend,
         navigateToAlbumDetail = navigateToAlbumDetail,
     )

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
@@ -52,26 +52,28 @@ fun AlbumScreen(
     onClickDrawer: () -> Unit,
     onCloseDrawer: () -> Unit,
     navigateToCreateAlbum: () -> Unit,
+    navigateToProfile: () -> Unit,
     navigateToFriend: () -> Unit,
     navigateToAlbumDetail: (AlbumItem) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     LaunchedEffect(SIDE_EFFECTS_KEY) {
         onEvent(AlbumContract.Event.OnGetAlbumList)
 
-        effectFlow().onEach { effect ->
-            when (effect) {
-                is AlbumContract.Effect.CloseDrawer -> {
-                    onCloseDrawer()
-                }
+        effectFlow()
+            .onEach { effect ->
+                when (effect) {
+                    is AlbumContract.Effect.CloseDrawer -> {
+                        onCloseDrawer()
+                    }
 
-                is AlbumContract.Effect.ShowSnackbar -> {
-                    snackbarHostState().showSnackbar(
-                        message = effect.message,
-                    )
+                    is AlbumContract.Effect.ShowSnackbar -> {
+                        snackbarHostState().showSnackbar(
+                            message = effect.message,
+                        )
+                    }
                 }
-            }
-        }.collect()
+            }.collect()
     }
 
     BackHandler(drawerState().isOpen) {
@@ -82,7 +84,7 @@ fun AlbumScreen(
         drawerState = drawerState(),
         drawerContent = {
             AlbumDrawerContent(
-                navigateToProfile = { /*TODO: Navigate to Profile*/ },
+                navigateToProfile = navigateToProfile,
                 navigateToFriend = navigateToFriend,
                 navigateToSetting = { /*TODO: Navigate to Setting*/ },
             )
@@ -102,9 +104,10 @@ fun AlbumScreen(
             LazyVerticalGrid(
                 columns = GridCells.Adaptive(minSize = 160.dp),
                 contentPadding = paddingValues,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(8.dp, 0.dp),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(8.dp, 0.dp),
             ) {
                 items(items = uiState().albumList, key = { it.id }) { albumItem ->
                     AlbumItemCard(
@@ -125,7 +128,7 @@ fun AlbumScreen(
 fun AlbumDrawerContent(
     navigateToProfile: () -> Unit,
     navigateToFriend: () -> Unit,
-    navigateToSetting: () -> Unit
+    navigateToSetting: () -> Unit,
 ) {
     ModalDrawerSheet {
         NavigationDrawerItem(
@@ -159,7 +162,7 @@ fun AlbumDrawerContent(
 @Composable
 fun AlbumTopAppBar(
     onClickDrawer: () -> Unit,
-    onClickSearch: () -> Unit
+    onClickSearch: () -> Unit,
 ) {
     CenterAlignedTopAppBar(
         title = { Text(text = "Album") },
@@ -177,9 +180,7 @@ fun AlbumTopAppBar(
 }
 
 @Composable
-fun CreateAlbumFAB(
-    onClick: () -> Unit
-) {
+fun CreateAlbumFAB(onClick: () -> Unit) {
     FloatingActionButton(onClick = onClick) {
         Icon(Icons.Default.Add, "")
     }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginContract.kt
@@ -14,17 +14,32 @@ class LoginContract {
     ) : UiState
 
     sealed interface Event : UiEvent {
-        data class OnEmailEntered(val email: String) : Event
-        data class OnPasswordEntered(val password: String) : Event
+        data class OnEmailEntered(
+            val email: String,
+        ) : Event
+
+        data class OnPasswordEntered(
+            val password: String,
+        ) : Event
+
         data object OnLoginClicked : Event
+
         data object OnSignUpClicked : Event
+
         data object OnRequestAutoLogin : Event
-        data class OnError(val errorMessage: String) : Event
+
+        data class OnError(
+            val errorMessage: String,
+        ) : Event
     }
 
     sealed interface Effect : UiEffect {
         data object NavigateToAlbum : Effect
+
         data object NavigateToSignUp : Effect
-        data class ShowSnackbar(val message: String) : Effect
+
+        data class ShowSnackbar(
+            val message: String,
+        ) : Effect
     }
 }

--- a/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginViewModel.kt
@@ -2,80 +2,72 @@ package cord.eoeo.momentwo.ui.login
 
 import android.util.Log
 import androidx.lifecycle.viewModelScope
-import cord.eoeo.momentwo.data.authentication.PreferenceRepository
-import cord.eoeo.momentwo.data.login.LoginRepository
+import cord.eoeo.momentwo.domain.login.RequestLoginUseCase
+import cord.eoeo.momentwo.domain.login.TryAutoLoginUseCase
 import cord.eoeo.momentwo.ui.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class LoginViewModel @Inject constructor(
-    private val loginRepository: LoginRepository,
-    private val preferenceRepository: PreferenceRepository,
-) : BaseViewModel<LoginContract.State, LoginContract.Event, LoginContract.Effect>() {
-    override fun createInitialState(): LoginContract.State = LoginContract.State()
+class LoginViewModel
+    @Inject
+    constructor(
+        private val requestLoginUseCase: RequestLoginUseCase,
+        private val tryAutoLoginUseCase: TryAutoLoginUseCase,
+    ) : BaseViewModel<LoginContract.State, LoginContract.Event, LoginContract.Effect>() {
+        override fun createInitialState(): LoginContract.State = LoginContract.State()
 
-    override fun handleEvent(newEvent: LoginContract.Event) {
-        when (newEvent) {
-            is LoginContract.Event.OnEmailEntered -> {
-                with(uiState.value) { setState(copy(email = newEvent.email)) }
-            }
-
-            is LoginContract.Event.OnPasswordEntered -> {
-                with(uiState.value) { setState(copy(password = newEvent.password)) }
-            }
-
-            is LoginContract.Event.OnLoginClicked -> {
-                viewModelScope.launch {
-                    with(uiState.value) {
-                        setState(copy(isLoading = true))
-                        loginRepository
-                            .requestLogin(email, password)
-                            .onSuccess { tokenItem ->
-                                preferenceRepository.storeAccessToken(tokenItem.accessToken)
-                                preferenceRepository.storeRefreshToken(tokenItem.refreshToken)
-                                setState(copy(isLoading = false, isSuccess = true, isError = false))
-                                setEffect { LoginContract.Effect.NavigateToAlbum }
-                            }.onFailure { exception ->
-                                Log.e("LoginFailure", "Login Failure", exception)
-                                setState(copy(isLoading = false, isSuccess = false, isError = true))
-                                setEvent(LoginContract.Event.OnError("로그인 요청에 실패했습니다"))
-                            }
-                    }
+        override fun handleEvent(newEvent: LoginContract.Event) {
+            when (newEvent) {
+                is LoginContract.Event.OnEmailEntered -> {
+                    with(uiState.value) { setState(copy(email = newEvent.email)) }
                 }
-            }
 
-            is LoginContract.Event.OnSignUpClicked -> {
-                setEffect { LoginContract.Effect.NavigateToSignUp }
-            }
+                is LoginContract.Event.OnPasswordEntered -> {
+                    with(uiState.value) { setState(copy(password = newEvent.password)) }
+                }
 
-            is LoginContract.Event.OnRequestAutoLogin -> {
-                viewModelScope.launch {
-                    with(uiState.value) {
-                        setState(copy(isLoading = true))
-                        preferenceRepository
-                            .getAccessToken()
-                            .onSuccess { accessToken ->
-                                if (accessToken.isNotEmpty()) {
-                                    Log.d("Login", "AutoLogin: $accessToken")
+                is LoginContract.Event.OnLoginClicked -> {
+                    viewModelScope.launch {
+                        with(uiState.value) {
+                            setState(copy(isLoading = true))
+                            requestLoginUseCase(email, password)
+                                .onSuccess {
                                     setState(copy(isLoading = false, isSuccess = true, isError = false))
                                     setEffect { LoginContract.Effect.NavigateToAlbum }
-                                } else {
-                                    Log.d("Login", "AutoLogin: No login history")
-                                    setState(copy(isLoading = false))
+                                }.onFailure { exception ->
+                                    Log.e("LoginFailure", "Login Failure", exception)
+                                    setState(copy(isLoading = false, isSuccess = false, isError = true))
+                                    setEvent(LoginContract.Event.OnError("로그인 요청에 실패했습니다"))
                                 }
-                            }.onFailure {
-                                Log.e("Login", "AutoLogin Failure", it)
-                                setState(copy(isLoading = false))
-                            }
+                        }
                     }
                 }
-            }
 
-            is LoginContract.Event.OnError -> {
-                setEffect { LoginContract.Effect.ShowSnackbar(newEvent.errorMessage) }
+                is LoginContract.Event.OnSignUpClicked -> {
+                    setEffect { LoginContract.Effect.NavigateToSignUp }
+                }
+
+                is LoginContract.Event.OnRequestAutoLogin -> {
+                    viewModelScope.launch {
+                        with(uiState.value) {
+                            setState(copy(isLoading = true))
+                            tryAutoLoginUseCase()
+                                .onSuccess {
+                                    setState(copy(isLoading = false, isSuccess = true, isError = false))
+                                    setEffect { LoginContract.Effect.NavigateToAlbum }
+                                }.onFailure { exception ->
+                                    Log.e("Login", "AutoLogin Failure", exception)
+                                    setState(copy(isLoading = false))
+                                }
+                        }
+                    }
+                }
+
+                is LoginContract.Event.OnError -> {
+                    setEffect { LoginContract.Effect.ShowSnackbar(newEvent.errorMessage) }
+                }
             }
         }
     }
-}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/model/ProfileItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/model/ProfileItem.kt
@@ -1,0 +1,9 @@
+package cord.eoeo.momentwo.ui.model
+
+data class ProfileItem(
+    val name: String,
+    val email: String,
+    val nickname: String,
+    val phone: String,
+    val profileImage: String,
+)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/model/TokenItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/model/TokenItem.kt
@@ -1,6 +1,0 @@
-package cord.eoeo.momentwo.ui.model
-
-data class TokenItem(
-    val accessToken: String,
-    val refreshToken: String,
-)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileContract.kt
@@ -1,0 +1,28 @@
+package cord.eoeo.momentwo.ui.profile
+
+import cord.eoeo.momentwo.ui.UiEffect
+import cord.eoeo.momentwo.ui.UiEvent
+import cord.eoeo.momentwo.ui.UiState
+
+class ProfileContract {
+    data class State(
+        val nickname: String? = null,
+        val isLoading: Boolean = false,
+        val isSuccess: Boolean = false,
+        val isError: Boolean = false,
+    ) : UiState
+
+    sealed interface Event : UiEvent {
+        data class OnError(
+            val errorMessage: String,
+        ) : Event
+    }
+
+    sealed interface Effect : UiEffect {
+        data object PopBackStack : Effect
+
+        data class ShowSnackbar(
+            val message: String,
+        ) : Effect
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileRoute.kt
@@ -1,0 +1,33 @@
+package cord.eoeo.momentwo.ui.profile
+
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.ImageLoader
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+fun ProfileRoute(
+    coroutineScope: CoroutineScope,
+    imageLoader: ImageLoader,
+    popBackStack: () -> Unit,
+    modifier: Modifier = Modifier,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    viewModel: ProfileViewModel = hiltViewModel(),
+) {
+    val uiState: ProfileContract.State by viewModel.uiState.collectAsStateWithLifecycle()
+
+    ProfileScreen(
+        coroutineScope = coroutineScope,
+        imageLoader = imageLoader,
+        uiState = { uiState },
+        effectFlow = { viewModel.effect },
+        onEvent = { event -> viewModel.setEvent(event) },
+        snackbarHostState = { snackbarHostState },
+        popBackStack = popBackStack,
+    )
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileScreen.kt
@@ -1,0 +1,85 @@
+package cord.eoeo.momentwo.ui.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import coil.ImageLoader
+import coil.imageLoader
+import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.ui.theme.MomentwoTheme
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+@Composable
+fun ProfileScreen(
+    coroutineScope: CoroutineScope,
+    imageLoader: ImageLoader,
+    uiState: () -> ProfileContract.State,
+    effectFlow: () -> Flow<ProfileContract.Effect>,
+    onEvent: (event: ProfileContract.Event) -> Unit,
+    snackbarHostState: () -> SnackbarHostState,
+    popBackStack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LaunchedEffect(SIDE_EFFECTS_KEY) {
+        effectFlow()
+            .onEach { effect ->
+                when (effect) {
+                    is ProfileContract.Effect.PopBackStack -> {
+                        popBackStack()
+                    }
+
+                    is ProfileContract.Effect.ShowSnackbar -> {
+                        coroutineScope.launch {
+                            snackbarHostState().showSnackbar(
+                                message = effect.message,
+                            )
+                        }
+                    }
+                }
+            }.collect()
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState()) },
+        modifier = Modifier.fillMaxSize(),
+    ) { paddingValues ->
+        Column(
+            modifier =
+                Modifier
+                    .padding(paddingValues)
+                    .padding(16.dp),
+        ) {
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun ProfileScreenPreview() {
+    MomentwoTheme {
+        ProfileScreen(
+            coroutineScope = rememberCoroutineScope(),
+            imageLoader = LocalContext.current.imageLoader,
+            uiState = { ProfileContract.State() },
+            effectFlow = { emptyFlow() },
+            onEvent = { },
+            snackbarHostState = { SnackbarHostState() },
+            popBackStack = { },
+        )
+    }
+}

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileViewModel.kt
@@ -1,0 +1,32 @@
+package cord.eoeo.momentwo.ui.profile
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.navigation.toRoute
+import cord.eoeo.momentwo.domain.profile.ProfileRepository
+import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.ui.MomentwoDestination
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class ProfileViewModel
+    @Inject
+    constructor(
+        private val profileRepository: ProfileRepository,
+        savedStateHandle: SavedStateHandle,
+    ) : BaseViewModel<ProfileContract.State, ProfileContract.Event, ProfileContract.Effect>() {
+        init {
+            val (nickname) = savedStateHandle.toRoute<MomentwoDestination.Profile>()
+            setState(uiState.value.copy(nickname = nickname))
+        }
+
+        override fun createInitialState(): ProfileContract.State = ProfileContract.State()
+
+        override fun handleEvent(newEvent: ProfileContract.Event) {
+            when (newEvent) {
+                is ProfileContract.Event.OnError -> {
+                    setEffect { ProfileContract.Effect.ShowSnackbar(newEvent.errorMessage) }
+                }
+            }
+        }
+    }


### PR DESCRIPTION
## PR 내용
### 유저 프로필 요청 기능 구현
- Profile Data Type 추가
- Profile Service, RemoteDataSource 구현 (닉네임으로 프로필 요청)
- 첫 로그인 시 Room에 Profile 정보를 저장하도록 구현
    - ProfileEntity, ProfileDao 구현
    - ProfileLocalDataSource 구현
    - 로그인 성공 시 토큰과 함께 프로필 정보 저장 (UseCase 구현)
- ProfileRepository 구현
    - 본인 정보 요청, 다른 유저의 정보 요청 분리 (Local or Remote)
- 로그인, 자동 로그인 로직을 Domain Layer로 이동 (UseCase)
    - 토큰 정보가 UI Layer까지 전달되지 않도록 수정 (Domain에서 확인 후 저장)
    - Profile 정보의 저장을 요청
    - DataStore에서 토큰 확인 후 자동 로그인 진행하는 로직을 UseCase로 분리
- UI Layer 기본 토대 작업
    - Profile Route, Screen 기본 구현
    - Profile Contract, ViewModel 기본 구현
    - Navigation 구현 (nickname 전달)
    - Album 화면 -> Profile 화면 연결

Resolve: #103 