### PR TITLE
refactor: :core:designsystem 모듈 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,8 @@ android {
 fun getLocalProperty(key: String): String = gradleLocalProperties(rootDir, providers).getProperty(key)
 
 dependencies {
+    implementation(project(":core:designsystem"))
+
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)
     implementation(libs.icons)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MainActivity.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MainActivity.kt
@@ -6,7 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.WindowCompat
 import coil.imageLoader
-import cord.eoeo.momentwo.ui.theme.MomentwoTheme
+import cord.eoeo.momentwo.core.designsystem.theme.MomentwoTheme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberListItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberListItem.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import cord.eoeo.momentwo.ui.model.MemberAuth
 import cord.eoeo.momentwo.ui.model.MemberItem
-import cord.eoeo.momentwo.ui.theme.starYellow
+import cord.eoeo.momentwo.core.designsystem.theme.starYellow
 
 @Composable
 fun MemberListItem(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/SearchUserDialog.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/SearchUserDialog.kt
@@ -46,7 +46,7 @@ import androidx.paging.compose.itemKey
 import coil.ImageLoader
 import coil.imageLoader
 import cord.eoeo.momentwo.ui.model.UserItem
-import cord.eoeo.momentwo.ui.theme.MomentwoTheme
+import cord.eoeo.momentwo.core.designsystem.theme.MomentwoTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/TextFieldDialog.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/TextFieldDialog.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import cord.eoeo.momentwo.ui.theme.MomentwoTheme
+import cord.eoeo.momentwo.core.designsystem.theme.MomentwoTheme
 
 @Composable
 fun TextFieldDialog(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailRoute.kt
@@ -18,7 +18,7 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.model.CommentItem
-import cord.eoeo.momentwo.ui.theme.backgroundDark
+import cord.eoeo.momentwo.core.designsystem.theme.backgroundDark
 import kotlinx.coroutines.CoroutineScope
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListItemBox.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListItemBox.kt
@@ -25,8 +25,8 @@ import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import cord.eoeo.momentwo.ui.model.PhotoItem
-import cord.eoeo.momentwo.ui.theme.favoriteBorder
-import cord.eoeo.momentwo.ui.theme.primaryDark
+import cord.eoeo.momentwo.core.designsystem.theme.favoriteBorder
+import cord.eoeo.momentwo.core.designsystem.theme.primaryDark
 
 @Composable
 fun PhotoListItemBox(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileScreen.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.imageLoader
 import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.theme.MomentwoTheme
+import cord.eoeo.momentwo.core.designsystem.theme.MomentwoTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    alias(libs.plugins.momentwo.android.library)
+    alias(libs.plugins.momentwo.android.library.compose)
+}
+
+android {
+    namespace = "cord.eoeo.momentwo.core.designsystem"
+}

--- a/core/designsystem/src/main/java/cord/eoeo/momentwo/core/designsystem/theme/Color.kt
+++ b/core/designsystem/src/main/java/cord/eoeo/momentwo/core/designsystem/theme/Color.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.theme
+package cord.eoeo.momentwo.core.designsystem.theme
 
 import androidx.compose.ui.graphics.Color
 

--- a/core/designsystem/src/main/java/cord/eoeo/momentwo/core/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/cord/eoeo/momentwo/core/designsystem/theme/Theme.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.theme
+package cord.eoeo.momentwo.core.designsystem.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme

--- a/core/designsystem/src/main/java/cord/eoeo/momentwo/core/designsystem/theme/Type.kt
+++ b/core/designsystem/src/main/java/cord/eoeo/momentwo/core/designsystem/theme/Type.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.theme
+package cord.eoeo.momentwo.core.designsystem.theme
 
 import androidx.compose.material3.Typography
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,4 +16,5 @@ dependencyResolutionManagement {
 
 rootProject.name = "Momentwo"
 include(":app")
+include(":core:designsystem")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 워밍업 — `:core:designsystem` 모듈을 분리합니다. (스택 최하단)

## 변경
- `:core:designsystem` 모듈 신설 (`momentwo.android.library` + `momentwo.android.library.compose`)
- `ui/theme/{Color,Theme,Type}.kt` → `core.designsystem.theme` 이동 (git rename)
- `:app`에 모듈 의존성 추가 + 참조 7개 파일 import 갱신

## 검증
- `./gradlew :core:designsystem:assembleDebug :app:assembleDebug` ✅
- 참고: `:app:lintDebug`는 본 변경과 무관한 기존 에러 2건(`PhotoDetailScreen`/`SignUpScreen`의 `UnusedMaterial3ScaffoldPaddingParameter`)으로 실패 — 별도 처리 예정, 본 PR 게이트는 assembleDebug

Closes #117
Part of #108