### PR TITLE
refactor: :core:model 모듈 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -46,6 +46,7 @@ fun getLocalProperty(key: String): String = gradleLocalProperties(rootDir, provi
 
 dependencies {
     implementation(project(":core:designsystem"))
+    implementation(project(":core:model"))
 
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/AlbumRepositoryImpl.kt
@@ -11,8 +11,8 @@ import cord.eoeo.momentwo.data.model.PresignedRequest
 import cord.eoeo.momentwo.data.model.UriRequestBody
 import cord.eoeo.momentwo.data.presigned.PresignedDataSource
 import cord.eoeo.momentwo.domain.album.AlbumRepository
-import cord.eoeo.momentwo.ui.model.AlbumItem
-import cord.eoeo.momentwo.ui.model.MemberAuth
+import cord.eoeo.momentwo.core.model.AlbumItem
+import cord.eoeo.momentwo.core.model.MemberAuth
 
 class AlbumRepositoryImpl(
     private val albumRemoteDataSource: AlbumDataSource,

--- a/app/src/main/java/cord/eoeo/momentwo/data/comment/CommentRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/comment/CommentRepository.kt
@@ -1,7 +1,7 @@
 package cord.eoeo.momentwo.data.comment
 
 import androidx.paging.PagingData
-import cord.eoeo.momentwo.ui.model.CommentItem
+import cord.eoeo.momentwo.core.model.CommentItem
 import kotlinx.coroutines.flow.Flow
 
 interface CommentRepository {

--- a/app/src/main/java/cord/eoeo/momentwo/data/comment/CommentRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/comment/CommentRepositoryImpl.kt
@@ -7,7 +7,7 @@ import androidx.paging.map
 import cord.eoeo.momentwo.data.comment.remote.CommentPagingSource
 import cord.eoeo.momentwo.data.model.CreateComment
 import cord.eoeo.momentwo.data.model.EditComment
-import cord.eoeo.momentwo.ui.model.CommentItem
+import cord.eoeo.momentwo.core.model.CommentItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/description/DescriptionRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/description/DescriptionRepository.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.description
 
-import cord.eoeo.momentwo.ui.model.DescriptionItem
+import cord.eoeo.momentwo.core.model.DescriptionItem
 
 interface DescriptionRepository {
     suspend fun writeDescription(

--- a/app/src/main/java/cord/eoeo/momentwo/data/description/DescriptionRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/description/DescriptionRepositoryImpl.kt
@@ -2,7 +2,7 @@ package cord.eoeo.momentwo.data.description
 
 import cord.eoeo.momentwo.data.model.CreateDescription
 import cord.eoeo.momentwo.data.model.EditDescription
-import cord.eoeo.momentwo.ui.model.DescriptionItem
+import cord.eoeo.momentwo.core.model.DescriptionItem
 
 class DescriptionRepositoryImpl(
     private val descriptionRemoteDataSource: DescriptionDataSource,

--- a/app/src/main/java/cord/eoeo/momentwo/data/friend/FriendRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/friend/FriendRepositoryImpl.kt
@@ -7,9 +7,9 @@ import androidx.paging.PagingData
 import androidx.paging.map
 import cord.eoeo.momentwo.data.friend.remote.SearchUserPagingSource
 import cord.eoeo.momentwo.domain.friend.FriendRepository
-import cord.eoeo.momentwo.ui.model.FriendItem
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.UserItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/app/src/main/java/cord/eoeo/momentwo/data/friend/local/entity/FriendEntity.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/friend/local/entity/FriendEntity.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.data.friend.local.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendItem
 
 @Entity(tableName = "friend")
 data class FriendEntity(

--- a/app/src/main/java/cord/eoeo/momentwo/data/login/LoginRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/login/LoginRepositoryImpl.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.data.login
 import cord.eoeo.momentwo.data.model.LoginRequest
 import cord.eoeo.momentwo.domain.login.LoginRepository
 import cord.eoeo.momentwo.domain.mapper.ProfileMapper
-import cord.eoeo.momentwo.domain.model.LoginData
+import cord.eoeo.momentwo.core.model.LoginData
 
 class LoginRepositoryImpl(
     private val loginRemoteDataSource: LoginDataSource,

--- a/app/src/main/java/cord/eoeo/momentwo/data/member/MemberRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/member/MemberRepository.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.member
 
-import cord.eoeo.momentwo.ui.model.MemberItem
+import cord.eoeo.momentwo.core.model.MemberItem
 
 interface MemberRepository {
     suspend fun exitFromAlbum(albumId: Int): Result<Unit>

--- a/app/src/main/java/cord/eoeo/momentwo/data/member/MemberRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/member/MemberRepositoryImpl.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.data.member
 import cord.eoeo.momentwo.data.model.AssignAdminToMember
 import cord.eoeo.momentwo.data.model.EditMembers
 import cord.eoeo.momentwo.data.model.InviteMembers
-import cord.eoeo.momentwo.ui.model.MemberItem
+import cord.eoeo.momentwo.core.model.MemberItem
 
 class MemberRepositoryImpl(
     private val memberRemoteDataSource: MemberDataSource,

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Album.kt
@@ -2,7 +2,7 @@ package cord.eoeo.momentwo.data.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
 
 @JsonClass(generateAdapter = true)
 data class CreateAlbumInfo(

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Comment.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Comment.kt
@@ -1,7 +1,7 @@
 package cord.eoeo.momentwo.data.model
 
 import com.squareup.moshi.JsonClass
-import cord.eoeo.momentwo.ui.model.CommentItem
+import cord.eoeo.momentwo.core.model.CommentItem
 
 @JsonClass(generateAdapter = true)
 data class CreateComment(

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Description.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Description.kt
@@ -1,7 +1,7 @@
 package cord.eoeo.momentwo.data.model
 
 import com.squareup.moshi.JsonClass
-import cord.eoeo.momentwo.ui.model.DescriptionItem
+import cord.eoeo.momentwo.core.model.DescriptionItem
 
 @JsonClass(generateAdapter = true)
 data class CreateDescription(

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Friend.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Friend.kt
@@ -2,8 +2,8 @@ package cord.eoeo.momentwo.data.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.UserItem
 
 @JsonClass(generateAdapter = true)
 data class FriendRequestResponse(

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/Member.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/Member.kt
@@ -2,8 +2,8 @@ package cord.eoeo.momentwo.data.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import cord.eoeo.momentwo.ui.model.MemberAuth
-import cord.eoeo.momentwo.ui.model.MemberItem
+import cord.eoeo.momentwo.core.model.MemberAuth
+import cord.eoeo.momentwo.core.model.MemberItem
 
 @JsonClass(generateAdapter = true)
 data class InviteMembers(

--- a/app/src/main/java/cord/eoeo/momentwo/data/model/SubAlbum.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/model/SubAlbum.kt
@@ -2,8 +2,8 @@ package cord.eoeo.momentwo.data.model
 
 import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
-import cord.eoeo.momentwo.ui.model.ImageItem
-import cord.eoeo.momentwo.ui.model.SubAlbumItem
+import cord.eoeo.momentwo.core.model.ImageItem
+import cord.eoeo.momentwo.core.model.SubAlbumItem
 
 @JsonClass(generateAdapter = true)
 data class CreateSubAlbumInfo(

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/PhotoRepositoryImpl.kt
@@ -19,7 +19,7 @@ import cord.eoeo.momentwo.data.model.UploadPhoto
 import cord.eoeo.momentwo.data.model.UriRequestBody
 import cord.eoeo.momentwo.data.presigned.PresignedDataSource
 import cord.eoeo.momentwo.domain.photo.PhotoRepository
-import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/local/entity/PhotoEntity.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/local/entity/PhotoEntity.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.data.photo.local.entity
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.core.model.PhotoItem
 
 @Entity(tableName = "photo")
 data class PhotoEntity(

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/ProfileRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/ProfileRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package cord.eoeo.momentwo.data.profile
 
 import cord.eoeo.momentwo.domain.mapper.ProfileMapper
-import cord.eoeo.momentwo.domain.model.Profile
+import cord.eoeo.momentwo.core.model.Profile
 import cord.eoeo.momentwo.domain.profile.ProfileRepository
 
 class ProfileRepositoryImpl(

--- a/app/src/main/java/cord/eoeo/momentwo/data/subalbum/SubAlbumRepositoryImpl.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/subalbum/SubAlbumRepositoryImpl.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.data.subalbum
 import cord.eoeo.momentwo.data.model.CreateSubAlbumInfo
 import cord.eoeo.momentwo.data.model.EditSubAlbumInfo
 import cord.eoeo.momentwo.domain.subalbum.SubAlbumRepository
-import cord.eoeo.momentwo.ui.model.SubAlbumItem
+import cord.eoeo.momentwo.core.model.SubAlbumItem
 
 class SubAlbumRepositoryImpl(
     private val subAlbumRemoteDataSource: SubAlbumDataSource,

--- a/app/src/main/java/cord/eoeo/momentwo/domain/album/AlbumRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/album/AlbumRepository.kt
@@ -1,8 +1,8 @@
 package cord.eoeo.momentwo.domain.album
 
 import android.net.Uri
-import cord.eoeo.momentwo.ui.model.AlbumItem
-import cord.eoeo.momentwo.ui.model.MemberAuth
+import cord.eoeo.momentwo.core.model.AlbumItem
+import cord.eoeo.momentwo.core.model.MemberAuth
 
 interface AlbumRepository {
     suspend fun requestCreateAlbum(

--- a/app/src/main/java/cord/eoeo/momentwo/domain/album/GetAlbumListUseCase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/album/GetAlbumListUseCase.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.domain.album
 
-import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
 
 class GetAlbumListUseCase(
     private val albumRepository: AlbumRepository,

--- a/app/src/main/java/cord/eoeo/momentwo/domain/friend/FriendRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/friend/FriendRepository.kt
@@ -1,9 +1,9 @@
 package cord.eoeo.momentwo.domain.friend
 
 import androidx.paging.PagingData
-import cord.eoeo.momentwo.ui.model.FriendItem
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.UserItem
 import kotlinx.coroutines.flow.Flow
 
 interface FriendRepository {

--- a/app/src/main/java/cord/eoeo/momentwo/domain/friend/GetFriendListUseCase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/friend/GetFriendListUseCase.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.domain.friend
 
-import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendItem
 
 class GetFriendListUseCase(
     private val friendRepository: FriendRepository,

--- a/app/src/main/java/cord/eoeo/momentwo/domain/login/LoginRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/login/LoginRepository.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.domain.login
 
-import cord.eoeo.momentwo.domain.model.LoginData
+import cord.eoeo.momentwo.core.model.LoginData
 
 interface LoginRepository {
     suspend fun requestLogin(

--- a/app/src/main/java/cord/eoeo/momentwo/domain/mapper/ProfileMapper.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/mapper/ProfileMapper.kt
@@ -2,8 +2,8 @@ package cord.eoeo.momentwo.domain.mapper
 
 import cord.eoeo.momentwo.data.model.UserProfile
 import cord.eoeo.momentwo.data.profile.local.entity.ProfileEntity
-import cord.eoeo.momentwo.domain.model.Profile
-import cord.eoeo.momentwo.ui.model.ProfileItem
+import cord.eoeo.momentwo.core.model.Profile
+import cord.eoeo.momentwo.core.model.ProfileItem
 import javax.inject.Inject
 
 class ProfileMapper

--- a/app/src/main/java/cord/eoeo/momentwo/domain/photo/PhotoRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/photo/PhotoRepository.kt
@@ -2,7 +2,7 @@ package cord.eoeo.momentwo.domain.photo
 
 import android.net.Uri
 import androidx.paging.PagingData
-import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.flow.Flow
 
 interface PhotoRepository {

--- a/app/src/main/java/cord/eoeo/momentwo/domain/profile/ProfileRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/profile/ProfileRepository.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.domain.profile
 
-import cord.eoeo.momentwo.domain.model.Profile
+import cord.eoeo.momentwo.core.model.Profile
 
 interface ProfileRepository {
     suspend fun storeProfile(profile: Profile): Result<Unit>

--- a/app/src/main/java/cord/eoeo/momentwo/domain/subalbum/SubAlbumRepository.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/subalbum/SubAlbumRepository.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.domain.subalbum
 
-import cord.eoeo.momentwo.ui.model.SubAlbumItem
+import cord.eoeo.momentwo.core.model.SubAlbumItem
 
 interface SubAlbumRepository {
     suspend fun requestCreateSubAlbum(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
@@ -1,7 +1,7 @@
 package cord.eoeo.momentwo.ui
 
 import androidx.navigation.NavHostController
-import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
 import kotlinx.serialization.Serializable
 
 sealed interface MomentwoDestination {

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumContract.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.ui.album
 import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
-import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
 
 class AlbumContract {
     data class State(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumRoute.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.AlbumItemCard
-import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailContract.kt
@@ -4,11 +4,11 @@ import android.net.Uri
 import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
-import cord.eoeo.momentwo.ui.model.AlbumItem
-import cord.eoeo.momentwo.ui.model.FriendItem
-import cord.eoeo.momentwo.ui.model.MemberAuth
-import cord.eoeo.momentwo.ui.model.MemberItem
-import cord.eoeo.momentwo.ui.model.SubAlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
+import cord.eoeo.momentwo.core.model.FriendItem
+import cord.eoeo.momentwo.core.model.MemberAuth
+import cord.eoeo.momentwo.core.model.MemberItem
+import cord.eoeo.momentwo.core.model.SubAlbumItem
 
 class AlbumDetailContract {
     data class State(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailScreen.kt
@@ -45,8 +45,8 @@ import cord.eoeo.momentwo.ui.albumdetail.subalbumlist.SubAlbumListScreen
 import cord.eoeo.momentwo.ui.composable.InviteDialog
 import cord.eoeo.momentwo.ui.composable.TextFieldDialog
 import cord.eoeo.momentwo.ui.model.BottomNavigationItem
-import cord.eoeo.momentwo.ui.model.MemberAuth
-import cord.eoeo.momentwo.ui.model.TextFieldDialogItem
+import cord.eoeo.momentwo.core.model.MemberAuth
+import cord.eoeo.momentwo.core.model.TextFieldDialogItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
@@ -11,7 +11,7 @@ import cord.eoeo.momentwo.domain.friend.GetFriendListUseCase
 import cord.eoeo.momentwo.domain.subalbum.SubAlbumRepository
 import cord.eoeo.momentwo.ui.BaseViewModel
 import cord.eoeo.momentwo.ui.MomentwoDestination
-import cord.eoeo.momentwo.ui.model.AlbumItem
+import cord.eoeo.momentwo.core.model.AlbumItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
@@ -30,7 +30,13 @@ class AlbumDetailViewModel
             val albumDetailItem = savedStateHandle.toRoute<MomentwoDestination.AlbumDetail>()
             setState(
                 uiState.value.copy(
-                    albumItem = AlbumItem.newInstance(albumDetailItem),
+                    albumItem = AlbumItem(
+                        id = albumDetailItem.id,
+                        title = albumDetailItem.title,
+                        subTitle = albumDetailItem.subTitle,
+                        imageUrl = albumDetailItem.imageUrl,
+                        subAlbumCount = 0, // TODO
+                    ),
                     imageUri = Uri.parse(albumDetailItem.imageUrl),
                 ),
             )

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingRoute.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.gestures.rememberScrollableState
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
-import cord.eoeo.momentwo.ui.model.MemberAuth
+import cord.eoeo.momentwo.core.model.MemberAuth
 
 @Composable
 fun AlbumSettingRoute(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/AlbumSettingScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import cord.eoeo.momentwo.ui.model.MemberAuth
+import cord.eoeo.momentwo.core.model.MemberAuth
 
 @Composable
 fun AlbumSettingScreen(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberListItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberListItem.kt
@@ -24,8 +24,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import cord.eoeo.momentwo.ui.model.MemberAuth
-import cord.eoeo.momentwo.ui.model.MemberItem
+import cord.eoeo.momentwo.core.model.MemberAuth
+import cord.eoeo.momentwo.core.model.MemberItem
 import cord.eoeo.momentwo.core.designsystem.theme.starYellow
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.LifecycleStartEffect
 import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.model.MemberItem
+import cord.eoeo.momentwo.core.model.MemberItem
 
 @Composable
 fun MemberScreen(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumItemCard.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumItemCard.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImage
-import cord.eoeo.momentwo.ui.model.SubAlbumItem
+import cord.eoeo.momentwo.core.model.SubAlbumItem
 
 @Composable
 fun SubAlbumItemCard(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumListScreen.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.model.SubAlbumItem
+import cord.eoeo.momentwo.core.model.SubAlbumItem
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/InviteDialog.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/InviteDialog.kt
@@ -32,8 +32,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
-import cord.eoeo.momentwo.ui.model.FriendItem
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.FriendItem
+import cord.eoeo.momentwo.core.model.UserItem
 
 @Composable
 fun InviteDialog(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/SearchUserDialog.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/SearchUserDialog.kt
@@ -45,7 +45,7 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import coil.ImageLoader
 import coil.imageLoader
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.UserItem
 import cord.eoeo.momentwo.core.designsystem.theme.MomentwoTheme
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/composable/UserItemBox.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/composable/UserItemBox.kt
@@ -21,7 +21,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.UserItem
 
 @Composable
 fun UserItemBox(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumContract.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.ui.createalbum
 import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
-import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendItem
 
 class CreateAlbumContract {
     data class State(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
@@ -38,7 +38,7 @@ import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.InviteDialog
 import cord.eoeo.momentwo.ui.composable.UserItemBox
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.UserItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendContract.kt
@@ -4,9 +4,9 @@ import androidx.paging.PagingData
 import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
-import cord.eoeo.momentwo.ui.model.FriendItem
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
-import cord.eoeo.momentwo.ui.model.UserItem
+import cord.eoeo.momentwo.core.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.UserItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendRoute.kt
@@ -11,7 +11,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendItem
 import kotlinx.coroutines.CoroutineScope
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendScreen.kt
@@ -32,7 +32,7 @@ import cord.eoeo.momentwo.ui.composable.SearchUserDialog
 import cord.eoeo.momentwo.ui.friend.friendlist.FriendListScreen
 import cord.eoeo.momentwo.ui.friend.friendrequest.FriendRequestRoute
 import cord.eoeo.momentwo.ui.model.BottomNavigationItem
-import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendlist/FriendListItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendlist/FriendListItem.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
-import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendItem
 
 @Composable
 fun FriendListItem(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendlist/FriendListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendlist/FriendListScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.Modifier
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.model.FriendItem
+import cord.eoeo.momentwo.core.model.FriendItem
 
 @Composable
 fun FriendListScreen(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestRoute.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
 import kotlinx.coroutines.CoroutineScope
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestScreen.kt
@@ -17,7 +17,7 @@ import androidx.lifecycle.compose.LifecycleStartEffect
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.RESUME_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/ReceivedFriendRequestItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/ReceivedFriendRequestItem.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
 
 @Composable
 fun ReceivedFriendRequestItem(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/SentFriendRequestItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/SentFriendRequestItem.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
-import cord.eoeo.momentwo.ui.model.FriendRequestItem
+import cord.eoeo.momentwo.core.model.FriendRequestItem
 
 @Composable
 fun SentFriendRequestItem(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/model/AlbumItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/model/AlbumItem.kt
@@ -1,22 +1,9 @@
 package cord.eoeo.momentwo.ui.model
 
-import cord.eoeo.momentwo.ui.MomentwoDestination
-
 data class AlbumItem(
     val id: Int,
     val title: String,
     val subTitle: String,
     val imageUrl: String,
     val subAlbumCount: Int,
-) {
-    companion object {
-        fun newInstance(albumDetail: MomentwoDestination.AlbumDetail): AlbumItem =
-            AlbumItem(
-                id = albumDetail.id,
-                title = albumDetail.title,
-                subTitle = albumDetail.subTitle,
-                imageUrl = albumDetail.imageUrl,
-                subAlbumCount = 0, // TODO
-            )
-    }
-}
+)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailContract.kt
@@ -4,8 +4,8 @@ import androidx.paging.PagingData
 import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
-import cord.eoeo.momentwo.ui.model.CommentItem
-import cord.eoeo.momentwo.ui.model.DescriptionItem
+import cord.eoeo.momentwo.core.model.CommentItem
+import cord.eoeo.momentwo.core.model.DescriptionItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailRoute.kt
@@ -17,7 +17,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.model.CommentItem
+import cord.eoeo.momentwo.core.model.CommentItem
 import cord.eoeo.momentwo.core.designsystem.theme.backgroundDark
 import kotlinx.coroutines.CoroutineScope
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailScreen.kt
@@ -48,7 +48,7 @@ import androidx.paging.compose.LazyPagingItems
 import coil.ImageLoader
 import coil.compose.AsyncImage
 import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.model.CommentItem
+import cord.eoeo.momentwo.core.model.CommentItem
 import cord.eoeo.momentwo.ui.photodetail.composable.CommentBottomSheet
 import cord.eoeo.momentwo.ui.photodetail.composable.DescriptionBottomSheet
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailViewModel.kt
@@ -11,7 +11,7 @@ import cord.eoeo.momentwo.domain.photo.DownloadPhotoUseCase
 import cord.eoeo.momentwo.domain.photo.UpdateIsLikedUseCase
 import cord.eoeo.momentwo.ui.BaseViewModel
 import cord.eoeo.momentwo.ui.MomentwoDestination
-import cord.eoeo.momentwo.ui.model.DescriptionItem
+import cord.eoeo.momentwo.core.model.DescriptionItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/CommentBottomSheet.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/CommentBottomSheet.kt
@@ -68,7 +68,7 @@ import androidx.paging.compose.itemKey
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
 import cord.eoeo.momentwo.ui.composable.TextFieldDialog
-import cord.eoeo.momentwo.ui.model.CommentItem
+import cord.eoeo.momentwo.core.model.CommentItem
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/DescriptionBottomSheet.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/DescriptionBottomSheet.kt
@@ -64,7 +64,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
-import cord.eoeo.momentwo.ui.model.DescriptionItem
+import cord.eoeo.momentwo.core.model.DescriptionItem
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
@@ -5,7 +5,7 @@ import androidx.paging.PagingData
 import cord.eoeo.momentwo.ui.UiEffect
 import cord.eoeo.momentwo.ui.UiEvent
 import cord.eoeo.momentwo.ui.UiState
-import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListItemBox.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListItemBox.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.compose.AsyncImage
-import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.core.model.PhotoItem
 import cord.eoeo.momentwo.core.designsystem.theme.favoriteBorder
 import cord.eoeo.momentwo.core.designsystem.theme.primaryDark
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListRoute.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListRoute.kt
@@ -15,7 +15,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
@@ -36,7 +36,7 @@ import androidx.paging.compose.itemKey
 import coil.ImageLoader
 import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.TextFieldDialog
-import cord.eoeo.momentwo.ui.model.PhotoItem
+import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow

--- a/core/model/build.gradle.kts
+++ b/core/model/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    alias(libs.plugins.momentwo.jvm.library)
+}

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/AlbumItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/AlbumItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class AlbumItem(
     val id: Int,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/CommentItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/CommentItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class CommentItem(
     val id: Int,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/DescriptionItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/DescriptionItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class DescriptionItem(
     val nickname: String,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/FriendItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/FriendItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class FriendItem(
     val nickname: String,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/FriendRequestItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/FriendRequestItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class FriendRequestItem(
     val userId: Int,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/ImageItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/ImageItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class ImageItem(
     val id: Int,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/LoginData.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/LoginData.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.domain.model
+package cord.eoeo.momentwo.core.model
 
 data class LoginData(
     val accessToken: String,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/MemberAuth.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/MemberAuth.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 enum class MemberAuth(
     val roleString: String,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/MemberItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/MemberItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class MemberItem(
     val id: Int,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/PhotoItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/PhotoItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class PhotoItem(
     val id: Int,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/Profile.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/Profile.kt
@@ -1,6 +1,6 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
-data class ProfileItem(
+data class Profile(
     val name: String,
     val email: String,
     val nickname: String,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/ProfileItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/ProfileItem.kt
@@ -1,6 +1,6 @@
-package cord.eoeo.momentwo.domain.model
+package cord.eoeo.momentwo.core.model
 
-data class Profile(
+data class ProfileItem(
     val name: String,
     val email: String,
     val nickname: String,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/SubAlbumItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/SubAlbumItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class SubAlbumItem(
     val id: Int,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/TextFieldDialogItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/TextFieldDialogItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class TextFieldDialogItem(
     val titleText: String,

--- a/core/model/src/main/java/cord/eoeo/momentwo/core/model/UserItem.kt
+++ b/core/model/src/main/java/cord/eoeo/momentwo/core/model/UserItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.model
 
 data class UserItem(
     val id: Int,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -17,4 +17,5 @@ dependencyResolutionManagement {
 rootProject.name = "Momentwo"
 include(":app")
 include(":core:designsystem")
+include(":core:model")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:model` 모듈 분리. (스택: `refactor/core-designsystem` 위)

> base가 `refactor/core-designsystem`인 스택 PR입니다. 하위 PR(#129) 병합 후 base를 `develop`으로 재지정합니다.

## 변경
- `:core:model` 신설 (`momentwo.jvm.library`, 순수 Kotlin)
- `ui/model` 13개 + `domain/model` 2개(LoginData, Profile) → `core.model` 이동
- `AlbumItem`의 companion `newInstance(MomentwoDestination.AlbumDetail)`를 제거하고 사용처(`AlbumDetailViewModel`)로 인라인 → 모델이 네비게이션 타입에 비의존
- `BottomNavigationItem`은 Compose(`ImageVector`) 의존이라 **이동 제외**, `:core:ui` 이관 때까지 app 잔존
- `:app` 의존성 추가 + import 일괄 갱신

## 검증
- `./gradlew :core:model:assemble :app:assembleDebug` ✅
- (게이트: assembleDebug — 기존 lint 이슈는 별도 처리)

Closes #111
Part of #108