### PR TITLE
refactor: :core:common 모듈 분리 (BaseViewModel + Dispatcher infra)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -47,6 +47,7 @@ fun getLocalProperty(key: String): String = gradleLocalProperties(rootDir, provi
 dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:model"))
+    implementation(project(":core:common"))
 
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumContract.kt
@@ -1,8 +1,8 @@
 package cord.eoeo.momentwo.ui.album
 
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 import cord.eoeo.momentwo.core.model.AlbumItem
 
 class AlbumContract {

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
@@ -32,7 +32,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.AlbumItemCard
 import cord.eoeo.momentwo.core.model.AlbumItem
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumViewModel.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.ui.album
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import cord.eoeo.momentwo.domain.album.GetAlbumListUseCase
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailContract.kt
@@ -1,9 +1,9 @@
 package cord.eoeo.momentwo.ui.albumdetail
 
 import android.net.Uri
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 import cord.eoeo.momentwo.core.model.AlbumItem
 import cord.eoeo.momentwo.core.model.FriendItem
 import cord.eoeo.momentwo.core.model.MemberAuth

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailScreen.kt
@@ -37,7 +37,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.albumdetail.albumsetting.AlbumSettingRoute
 import cord.eoeo.momentwo.ui.albumdetail.albumsetting.ChangeImageRoute
 import cord.eoeo.momentwo.ui.albumdetail.member.MemberScreen

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
@@ -9,7 +9,7 @@ import cord.eoeo.momentwo.data.member.MemberRepository
 import cord.eoeo.momentwo.domain.album.AlbumRepository
 import cord.eoeo.momentwo.domain.friend.GetFriendListUseCase
 import cord.eoeo.momentwo.domain.subalbum.SubAlbumRepository
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import cord.eoeo.momentwo.ui.MomentwoDestination
 import cord.eoeo.momentwo.core.model.AlbumItem
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.AlbumItemCard
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/member/MemberScreen.kt
@@ -7,7 +7,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.LifecycleStartEffect
-import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.START_EFFECTS_KEY
 import cord.eoeo.momentwo.core.model.MemberItem
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/subalbumlist/SubAlbumListScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.START_EFFECTS_KEY
 import cord.eoeo.momentwo.core.model.SubAlbumItem
 
 @OptIn(ExperimentalFoundationApi::class)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumContract.kt
@@ -1,8 +1,8 @@
 package cord.eoeo.momentwo.ui.createalbum
 
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 import cord.eoeo.momentwo.core.model.FriendItem
 
 class CreateAlbumContract {

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
@@ -34,8 +34,8 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.LifecycleStartEffect
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.START_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.InviteDialog
 import cord.eoeo.momentwo.ui.composable.UserItemBox
 import cord.eoeo.momentwo.core.model.UserItem

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.lifecycle.viewModelScope
 import cord.eoeo.momentwo.domain.album.RequestCreateAlbumUseCase
 import cord.eoeo.momentwo.domain.friend.GetFriendListUseCase
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendContract.kt
@@ -1,9 +1,9 @@
 package cord.eoeo.momentwo.ui.friend
 
 import androidx.paging.PagingData
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 import cord.eoeo.momentwo.core.model.FriendItem
 import cord.eoeo.momentwo.core.model.FriendRequestItem
 import cord.eoeo.momentwo.core.model.UserItem

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendScreen.kt
@@ -27,7 +27,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.paging.compose.LazyPagingItems
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.SearchUserDialog
 import cord.eoeo.momentwo.ui.friend.friendlist.FriendListScreen
 import cord.eoeo.momentwo.ui.friend.friendrequest.FriendRequestRoute

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendViewModel.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.ui.friend
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import cord.eoeo.momentwo.domain.friend.FriendRepository
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/FriendRequestScreen.kt
@@ -15,8 +15,8 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.compose.LifecycleResumeEffect
 import androidx.lifecycle.compose.LifecycleStartEffect
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.RESUME_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.START_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.RESUME_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.START_EFFECTS_KEY
 import cord.eoeo.momentwo.core.model.FriendRequestItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginContract.kt
@@ -1,8 +1,8 @@
 package cord.eoeo.momentwo.ui.login
 
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 
 class LoginContract {
     data class State(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect

--- a/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/login/LoginViewModel.kt
@@ -4,7 +4,7 @@ import android.util.Log
 import androidx.lifecycle.viewModelScope
 import cord.eoeo.momentwo.domain.login.RequestLoginUseCase
 import cord.eoeo.momentwo.domain.login.TryAutoLoginUseCase
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailContract.kt
@@ -1,9 +1,9 @@
 package cord.eoeo.momentwo.ui.photodetail
 
 import androidx.paging.PagingData
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 import cord.eoeo.momentwo.core.model.CommentItem
 import cord.eoeo.momentwo.core.model.DescriptionItem
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailScreen.kt
@@ -47,7 +47,7 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.paging.compose.LazyPagingItems
 import coil.ImageLoader
 import coil.compose.AsyncImage
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.core.model.CommentItem
 import cord.eoeo.momentwo.ui.photodetail.composable.CommentBottomSheet
 import cord.eoeo.momentwo.ui.photodetail.composable.DescriptionBottomSheet

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailViewModel.kt
@@ -9,7 +9,7 @@ import cord.eoeo.momentwo.data.description.DescriptionRepository
 import cord.eoeo.momentwo.data.like.LikeRepository
 import cord.eoeo.momentwo.domain.photo.DownloadPhotoUseCase
 import cord.eoeo.momentwo.domain.photo.UpdateIsLikedUseCase
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import cord.eoeo.momentwo.ui.MomentwoDestination
 import cord.eoeo.momentwo.core.model.DescriptionItem
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListContract.kt
@@ -2,9 +2,9 @@ package cord.eoeo.momentwo.ui.photolist
 
 import android.net.Uri
 import androidx.paging.PagingData
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.sp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.composable.TextFieldDialog
 import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListViewModel.kt
@@ -6,7 +6,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import cord.eoeo.momentwo.domain.photo.PhotoRepository
 import cord.eoeo.momentwo.domain.subalbum.ChangeSubAlbumTitleUseCase
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import cord.eoeo.momentwo.ui.MomentwoDestination
 import cord.eoeo.momentwo.ui.photolist.PhotoListContract.Effect.ShowSnackbar
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileContract.kt
@@ -1,8 +1,8 @@
 package cord.eoeo.momentwo.ui.profile
 
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 
 class ProfileContract {
     data class State(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import coil.imageLoader
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.core.designsystem.theme.MomentwoTheme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileViewModel.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.ui.profile
 import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import cord.eoeo.momentwo.domain.profile.ProfileRepository
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import cord.eoeo.momentwo.ui.MomentwoDestination
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject

--- a/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpContract.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpContract.kt
@@ -1,9 +1,9 @@
 package cord.eoeo.momentwo.ui.signup
 
 import cord.eoeo.momentwo.data.model.User
-import cord.eoeo.momentwo.ui.UiEffect
-import cord.eoeo.momentwo.ui.UiEvent
-import cord.eoeo.momentwo.ui.UiState
+import cord.eoeo.momentwo.core.common.UiEffect
+import cord.eoeo.momentwo.core.common.UiEvent
+import cord.eoeo.momentwo.core.common.UiState
 
 class SignUpContract {
     data class State(

--- a/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpScreen.kt
@@ -29,7 +29,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import cord.eoeo.momentwo.ui.SIDE_EFFECTS_KEY
+import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.ui.signup.transformation.DateVisualTransformation
 import cord.eoeo.momentwo.ui.signup.transformation.PhoneVisualTransformation
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpViewModel.kt
@@ -3,7 +3,7 @@ package cord.eoeo.momentwo.ui.signup
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import cord.eoeo.momentwo.data.signup.SignUpRepository
-import cord.eoeo.momentwo.ui.BaseViewModel
+import cord.eoeo.momentwo.core.common.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    alias(libs.plugins.momentwo.android.library)
+    alias(libs.plugins.momentwo.android.hilt)
+}
+
+android {
+    namespace = "cord.eoeo.momentwo.core.common"
+}
+
+dependencies {
+    implementation(libs.lifecycle.viewmodel)
+}

--- a/core/common/src/main/java/cord/eoeo/momentwo/core/common/BaseViewModel.kt
+++ b/core/common/src/main/java/cord/eoeo/momentwo/core/common/BaseViewModel.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui
+package cord.eoeo.momentwo.core.common
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/core/common/src/main/java/cord/eoeo/momentwo/core/common/dispatcher/DispatchersModule.kt
+++ b/core/common/src/main/java/cord/eoeo/momentwo/core/common/dispatcher/DispatchersModule.kt
@@ -1,0 +1,24 @@
+package cord.eoeo.momentwo.core.common.dispatcher
+
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DispatchersModule {
+    @Provides
+    @IoDispatcher
+    fun provideIoDispatcher(): CoroutineDispatcher = Dispatchers.IO
+
+    @Provides
+    @DefaultDispatcher
+    fun provideDefaultDispatcher(): CoroutineDispatcher = Dispatchers.Default
+
+    @Provides
+    @MainDispatcher
+    fun provideMainDispatcher(): CoroutineDispatcher = Dispatchers.Main
+}

--- a/core/common/src/main/java/cord/eoeo/momentwo/core/common/dispatcher/MomentwoDispatchers.kt
+++ b/core/common/src/main/java/cord/eoeo/momentwo/core/common/dispatcher/MomentwoDispatchers.kt
@@ -1,0 +1,15 @@
+package cord.eoeo.momentwo.core.common.dispatcher
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class IoDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDispatcher
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class MainDispatcher

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,4 +18,5 @@ rootProject.name = "Momentwo"
 include(":app")
 include(":core:designsystem")
 include(":core:model")
+include(":core:common")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:common` 모듈 분리. (스택: `refactor/core-model` 위)

> base가 `refactor/core-model`인 스택 PR입니다. 하위 PR(#130)이 develop에 병합되면 base를 재지정합니다.

## 변경
- `:core:common` 신설 (`momentwo.android.library` + `momentwo.android.hilt`)
- `@IoDispatcher`/`@DefaultDispatcher`/`@MainDispatcher` 한정자 + `DispatchersModule`(`@InstallIn(SingletonComponent)`) 신설
- MVI 베이스(`BaseViewModel`, `UiState`/`UiEvent`/`UiEffect`, `*_EFFECTS_KEY`) → `core.common` 이동 (심볼 단위 import 갱신)
- `:app` 의존성 추가

## 스코프 결정
- DataSource/Repository의 하드코딩된 `Dispatchers.IO`(~16개 DataSource의 생성자 기본값)를 `@IoDispatcher` 주입으로 전환하는 작업은 **이 파일들이 `:core:data`로 이동하는 PR에서 이동과 함께** 처리한다(이중 변경 회피). 본 PR은 주입 인프라만 제공.

## 검증
- `./gradlew :core:common:assembleDebug :app:assembleDebug` ✅

Closes #112
Part of #108