### PR TITLE
refactor: :core:ui 모듈 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:model"))
     implementation(project(":core:common"))
+    implementation(project(":core:ui"))
 
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/album/AlbumScreen.kt
@@ -33,7 +33,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.composable.AlbumItemCard
+import cord.eoeo.momentwo.core.ui.AlbumItemCard
 import cord.eoeo.momentwo.core.model.AlbumItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailScreen.kt
@@ -42,9 +42,9 @@ import cord.eoeo.momentwo.ui.albumdetail.albumsetting.AlbumSettingRoute
 import cord.eoeo.momentwo.ui.albumdetail.albumsetting.ChangeImageRoute
 import cord.eoeo.momentwo.ui.albumdetail.member.MemberScreen
 import cord.eoeo.momentwo.ui.albumdetail.subalbumlist.SubAlbumListScreen
-import cord.eoeo.momentwo.ui.composable.InviteDialog
-import cord.eoeo.momentwo.ui.composable.TextFieldDialog
-import cord.eoeo.momentwo.ui.model.BottomNavigationItem
+import cord.eoeo.momentwo.core.ui.InviteDialog
+import cord.eoeo.momentwo.core.ui.TextFieldDialog
+import cord.eoeo.momentwo.core.ui.BottomNavigationItem
 import cord.eoeo.momentwo.core.model.MemberAuth
 import cord.eoeo.momentwo.core.model.TextFieldDialogItem
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/albumsetting/ChangeImageScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import coil.ImageLoader
 import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.composable.AlbumItemCard
+import cord.eoeo.momentwo.core.ui.AlbumItemCard
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 

--- a/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/createalbum/CreateAlbumScreen.kt
@@ -36,8 +36,8 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.LifecycleStartEffect
 import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
 import cord.eoeo.momentwo.core.common.START_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.composable.InviteDialog
-import cord.eoeo.momentwo.ui.composable.UserItemBox
+import cord.eoeo.momentwo.core.ui.InviteDialog
+import cord.eoeo.momentwo.core.ui.UserItemBox
 import cord.eoeo.momentwo.core.model.UserItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/FriendScreen.kt
@@ -28,10 +28,10 @@ import androidx.navigation.compose.composable
 import androidx.paging.compose.LazyPagingItems
 import coil.ImageLoader
 import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.composable.SearchUserDialog
+import cord.eoeo.momentwo.core.ui.SearchUserDialog
 import cord.eoeo.momentwo.ui.friend.friendlist.FriendListScreen
 import cord.eoeo.momentwo.ui.friend.friendrequest.FriendRequestRoute
-import cord.eoeo.momentwo.ui.model.BottomNavigationItem
+import cord.eoeo.momentwo.core.ui.BottomNavigationItem
 import cord.eoeo.momentwo.core.model.FriendItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendlist/FriendListItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendlist/FriendListItem.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
+import cord.eoeo.momentwo.core.ui.CircleAsyncImage
 import cord.eoeo.momentwo.core.model.FriendItem
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/ReceivedFriendRequestItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/ReceivedFriendRequestItem.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
+import cord.eoeo.momentwo.core.ui.CircleAsyncImage
 import cord.eoeo.momentwo.core.model.FriendRequestItem
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/SentFriendRequestItem.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/friend/friendrequest/SentFriendRequestItem.kt
@@ -19,7 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
+import cord.eoeo.momentwo.core.ui.CircleAsyncImage
 import cord.eoeo.momentwo.core.model.FriendRequestItem
 
 @Composable

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/CommentBottomSheet.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/CommentBottomSheet.kt
@@ -66,8 +66,8 @@ import androidx.compose.ui.unit.sp
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
-import cord.eoeo.momentwo.ui.composable.TextFieldDialog
+import cord.eoeo.momentwo.core.ui.CircleAsyncImage
+import cord.eoeo.momentwo.core.ui.TextFieldDialog
 import cord.eoeo.momentwo.core.model.CommentItem
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/DescriptionBottomSheet.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/composable/DescriptionBottomSheet.kt
@@ -63,7 +63,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.ImageLoader
-import cord.eoeo.momentwo.ui.composable.CircleAsyncImage
+import cord.eoeo.momentwo.core.ui.CircleAsyncImage
 import cord.eoeo.momentwo.core.model.DescriptionItem
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListScreen.kt
@@ -35,7 +35,7 @@ import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
 import coil.ImageLoader
 import cord.eoeo.momentwo.core.common.SIDE_EFFECTS_KEY
-import cord.eoeo.momentwo.ui.composable.TextFieldDialog
+import cord.eoeo.momentwo.core.ui.TextFieldDialog
 import cord.eoeo.momentwo.core.model.PhotoItem
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    alias(libs.plugins.momentwo.android.library)
+    alias(libs.plugins.momentwo.android.library.compose)
+}
+
+android {
+    namespace = "cord.eoeo.momentwo.core.ui"
+}
+
+dependencies {
+    implementation(project(":core:designsystem"))
+    implementation(project(":core:model"))
+
+    implementation(libs.icons)
+    implementation(libs.icons.extended)
+    implementation(libs.coil)
+    implementation(libs.coil.compose)
+}

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -15,4 +15,6 @@ dependencies {
     implementation(libs.icons.extended)
     implementation(libs.coil)
     implementation(libs.coil.compose)
+    implementation(libs.paging)
+    implementation(libs.paging.compose)
 }

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/AlbumItemCard.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/AlbumItemCard.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.composable
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/BottomNavigationItem.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/BottomNavigationItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.model
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.ui.graphics.vector.ImageVector
 

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/CheckboxListItem.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/CheckboxListItem.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.composable
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/CircleAsyncImage.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/CircleAsyncImage.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.composable
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.aspectRatio

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/InviteDialog.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/InviteDialog.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.composable
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/SearchUserDialog.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/SearchUserDialog.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.composable
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.fillMaxHeight

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/TextFieldDialog.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/TextFieldDialog.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.composable
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/UserItemBox.kt
+++ b/core/ui/src/main/java/cord/eoeo/momentwo/core/ui/UserItemBox.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.ui.composable
+package cord.eoeo.momentwo.core.ui
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,4 +19,5 @@ include(":app")
 include(":core:designsystem")
 include(":core:model")
 include(":core:common")
+include(":core:ui")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:ui` 모듈 분리. (스택: `refactor/core-common` 위)

> base가 `refactor/core-common`인 스택 PR입니다. 하위 PR들이 develop에 병합되면 base를 재지정합니다.

## 변경
- `:core:ui` 신설 (`momentwo.android.library` + `momentwo.android.library.compose`), 의존: `:core:designsystem`, `:core:model`, coil, material-icons, paging
- `ui/composable` 7개(AlbumItemCard, CheckboxListItem, CircleAsyncImage, InviteDialog, SearchUserDialog, TextFieldDialog, UserItemBox) → `core.ui` 이동
- `BottomNavigationItem`(Compose `ImageVector` 의존이라 `:core:model`에서 제외했던 것) → `core.ui` 이동
- `:app` 의존성 추가 + import 갱신

## 검증
- `./gradlew :core:ui:assembleDebug :app:assembleDebug` ✅
- `SearchUserDialog`의 Paging3 사용으로 `paging`/`paging-compose` 의존을 모듈에 추가

Closes #118
Part of #108