### PR TITLE
refactor: :core:datastore 모듈 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -49,6 +49,7 @@ dependencies {
     implementation(project(":core:model"))
     implementation(project(":core:common"))
     implementation(project(":core:ui"))
+    implementation(project(":core:datastore"))
 
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)

--- a/app/src/main/java/cord/eoeo/momentwo/data/authentication/AuthAuthenticator.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/authentication/AuthAuthenticator.kt
@@ -1,6 +1,7 @@
 package cord.eoeo.momentwo.data.authentication
 
 import android.util.Log
+import cord.eoeo.momentwo.core.datastore.PreferenceRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/cord/eoeo/momentwo/data/authentication/AuthInterceptor.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/authentication/AuthInterceptor.kt
@@ -1,5 +1,6 @@
 package cord.eoeo.momentwo.data.authentication
 
+import cord.eoeo.momentwo.core.datastore.PreferenceRepository
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
 import okhttp3.Response

--- a/app/src/main/java/cord/eoeo/momentwo/di/AuthModule.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/di/AuthModule.kt
@@ -1,35 +1,17 @@
 package cord.eoeo.momentwo.di
 
-import android.content.Context
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
+import cord.eoeo.momentwo.core.datastore.PreferenceRepository
 import cord.eoeo.momentwo.data.authentication.AuthAuthenticator
 import cord.eoeo.momentwo.data.authentication.AuthInterceptor
-import cord.eoeo.momentwo.data.authentication.PreferenceRepository
-import cord.eoeo.momentwo.data.authentication.PreferenceRepositoryImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object AuthModule {
-    private val Context.userDataStore: DataStore<Preferences> by preferencesDataStore("momentwo")
-
-    @Provides
-    @Singleton
-    fun provideUserDataStore(
-        @ApplicationContext context: Context,
-    ): DataStore<Preferences> = context.userDataStore
-
-    @Provides
-    @Singleton
-    fun providePreferenceRepository(userDataStore: DataStore<Preferences>): PreferenceRepository = PreferenceRepositoryImpl(userDataStore)
-
     @Provides
     @Singleton
     fun provideAuthInterceptor(preferenceRepository: PreferenceRepository): AuthInterceptor = AuthInterceptor(preferenceRepository)

--- a/app/src/main/java/cord/eoeo/momentwo/di/LoginModule.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/di/LoginModule.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.di
 
-import cord.eoeo.momentwo.data.authentication.PreferenceRepository
+import cord.eoeo.momentwo.core.datastore.PreferenceRepository
 import cord.eoeo.momentwo.data.login.LoginDataSource
 import cord.eoeo.momentwo.data.login.LoginRepositoryImpl
 import cord.eoeo.momentwo.data.login.remote.LoginRemoteDataSource

--- a/app/src/main/java/cord/eoeo/momentwo/domain/login/RequestLoginUseCase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/login/RequestLoginUseCase.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.domain.login
 
-import cord.eoeo.momentwo.data.authentication.PreferenceRepository
+import cord.eoeo.momentwo.core.datastore.PreferenceRepository
 import cord.eoeo.momentwo.domain.profile.ProfileRepository
 
 class RequestLoginUseCase(

--- a/app/src/main/java/cord/eoeo/momentwo/domain/login/TryAutoLoginUseCase.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/domain/login/TryAutoLoginUseCase.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.domain.login
 
-import cord.eoeo.momentwo.data.authentication.PreferenceRepository
+import cord.eoeo.momentwo.core.datastore.PreferenceRepository
 
 class TryAutoLoginUseCase(
     private val preferenceRepository: PreferenceRepository,

--- a/core/datastore/build.gradle.kts
+++ b/core/datastore/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    alias(libs.plugins.momentwo.android.library)
+    alias(libs.plugins.momentwo.android.hilt)
+}
+
+android {
+    namespace = "cord.eoeo.momentwo.core.datastore"
+}
+
+dependencies {
+    implementation(libs.datastore)
+}

--- a/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/DataStoreModule.kt
+++ b/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/DataStoreModule.kt
@@ -1,0 +1,29 @@
+package cord.eoeo.momentwo.core.datastore
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object DataStoreModule {
+    private val Context.userDataStore: DataStore<Preferences> by preferencesDataStore("momentwo")
+
+    @Provides
+    @Singleton
+    fun provideUserDataStore(
+        @ApplicationContext context: Context,
+    ): DataStore<Preferences> = context.userDataStore
+
+    @Provides
+    @Singleton
+    fun providePreferenceRepository(userDataStore: DataStore<Preferences>): PreferenceRepository =
+        PreferenceRepositoryImpl(userDataStore)
+}

--- a/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/PreferenceKeys.kt
+++ b/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/PreferenceKeys.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.data.authentication
+package cord.eoeo.momentwo.core.datastore
 
 import androidx.datastore.preferences.core.stringPreferencesKey
 

--- a/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/PreferenceRepository.kt
+++ b/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/PreferenceRepository.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.data.authentication
+package cord.eoeo.momentwo.core.datastore
 
 interface PreferenceRepository {
     suspend fun storeAccessToken(accessToken: String)

--- a/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/PreferenceRepositoryImpl.kt
+++ b/core/datastore/src/main/java/cord/eoeo/momentwo/core/datastore/PreferenceRepositoryImpl.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.data.authentication
+package cord.eoeo.momentwo.core.datastore
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.core.IOException

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -20,4 +20,5 @@ include(":core:designsystem")
 include(":core:model")
 include(":core:common")
 include(":core:ui")
+include(":core:datastore")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:datastore` 모듈 분리. (스택: `refactor/core-ui` 위)

> base가 `refactor/core-ui`인 스택 PR입니다. 하위 PR들이 develop에 병합되면 base를 재지정합니다.

## 변경
- `:core:datastore` 신설 (`momentwo.android.library` + `momentwo.android.hilt`, `datastore` 의존)
- `PreferenceRepository`/`PreferenceRepositoryImpl`/`PreferenceKeys` → `core.datastore` 이동
- `DataStoreModule` 신설(`DataStore<Preferences>` + `PreferenceRepository` 제공) — 기존 `AuthModule`의 datastore 파트 이관
- `AuthModule`(app)은 `AuthInterceptor`/`AuthAuthenticator`(network 파트)만 유지 → **AuthModule 분할**
- 같은 패키지라 import 없이 `PreferenceRepository`를 참조하던 `AuthInterceptor`/`AuthAuthenticator`에 import 명시, 그 외 FQN 참조(Login 모듈/UseCase) 갱신

## 검증
- `./gradlew :core:datastore:assembleDebug :app:assembleDebug` ✅

Closes #114
Part of #108