### PR TITLE
refactor: :core:network 모듈 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
-
 plugins {
     alias(libs.plugins.momentwo.android.application)
     alias(libs.plugins.momentwo.android.application.compose)
@@ -20,8 +18,6 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-
-        buildConfigField("String", "BASE_URL", getLocalProperty("BASE_URL"))
     }
 
     buildTypes {
@@ -42,14 +38,13 @@ android {
     }
 }
 
-fun getLocalProperty(key: String): String = gradleLocalProperties(rootDir, providers).getProperty(key)
-
 dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:model"))
     implementation(project(":core:common"))
     implementation(project(":core:ui"))
     implementation(project(":core:datastore"))
+    implementation(project(":core:network"))
 
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)

--- a/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/album/remote/AlbumService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.album.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.AlbumImage
 import cord.eoeo.momentwo.data.model.AlbumInfoList
 import cord.eoeo.momentwo.data.model.AlbumRole

--- a/app/src/main/java/cord/eoeo/momentwo/data/comment/remote/CommentService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/comment/remote/CommentService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.comment.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.CommentPage
 import cord.eoeo.momentwo.data.model.CreateComment
 import cord.eoeo.momentwo.data.model.EditComment

--- a/app/src/main/java/cord/eoeo/momentwo/data/description/remote/DescriptionService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/description/remote/DescriptionService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.description.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.CreateDescription
 import cord.eoeo.momentwo.data.model.Description
 import cord.eoeo.momentwo.data.model.EditDescription

--- a/app/src/main/java/cord/eoeo/momentwo/data/friend/remote/FriendService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/friend/remote/FriendService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.friend.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.FriendPage
 import cord.eoeo.momentwo.data.model.FriendRequestResponse
 import cord.eoeo.momentwo.data.model.ReceivedFriendRequestList

--- a/app/src/main/java/cord/eoeo/momentwo/data/like/remote/LikeService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/like/remote/LikeService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.like.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.LikeCount
 import cord.eoeo.momentwo.data.model.LikeRequest
 import retrofit2.http.Body

--- a/app/src/main/java/cord/eoeo/momentwo/data/login/remote/LoginService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/login/remote/LoginService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.login.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.LoginRequest
 import cord.eoeo.momentwo.data.model.UserProfile
 import retrofit2.Response

--- a/app/src/main/java/cord/eoeo/momentwo/data/member/remote/MemberService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/member/remote/MemberService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.member.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.AssignAdminToMember
 import cord.eoeo.momentwo.data.model.EditMembers
 import cord.eoeo.momentwo.data.model.InviteMembers

--- a/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/photo/remote/PhotoService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.photo.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.LikedPhotoList
 import cord.eoeo.momentwo.data.model.PhotoPage
 import cord.eoeo.momentwo.data.model.PresignedRequest

--- a/app/src/main/java/cord/eoeo/momentwo/data/profile/remote/ProfileService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/profile/remote/ProfileService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.profile.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.UserProfile
 import retrofit2.http.GET
 import retrofit2.http.Query

--- a/app/src/main/java/cord/eoeo/momentwo/data/signup/remote/SignUpService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/signup/remote/SignUpService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.signup.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.User
 import retrofit2.Response
 import retrofit2.http.Body

--- a/app/src/main/java/cord/eoeo/momentwo/data/subalbum/remote/SubAlbumService.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/data/subalbum/remote/SubAlbumService.kt
@@ -1,6 +1,6 @@
 package cord.eoeo.momentwo.data.subalbum.remote
 
-import cord.eoeo.momentwo.data.MomentwoApi
+import cord.eoeo.momentwo.core.network.MomentwoApi
 import cord.eoeo.momentwo.data.model.CreateSubAlbumInfo
 import cord.eoeo.momentwo.data.model.EditSubAlbumInfo
 import cord.eoeo.momentwo.data.model.SubAlbumList

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,0 +1,27 @@
+import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
+
+plugins {
+    alias(libs.plugins.momentwo.android.library)
+    alias(libs.plugins.momentwo.android.network)
+    alias(libs.plugins.momentwo.android.hilt)
+}
+
+android {
+    namespace = "cord.eoeo.momentwo.core.network"
+
+    defaultConfig {
+        buildConfigField("String", "BASE_URL", getLocalProperty("BASE_URL"))
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+fun getLocalProperty(key: String): String = gradleLocalProperties(rootDir, providers).getProperty(key)
+
+dependencies {
+    implementation(project(":core:datastore"))
+
+    implementation(libs.coroutines.core)
+}

--- a/core/network/src/main/java/cord/eoeo/momentwo/core/network/ApiModule.kt
+++ b/core/network/src/main/java/cord/eoeo/momentwo/core/network/ApiModule.kt
@@ -1,10 +1,10 @@
-package cord.eoeo.momentwo.di
+package cord.eoeo.momentwo.core.network
 
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import cord.eoeo.momentwo.data.MomentwoApi
-import cord.eoeo.momentwo.data.authentication.AuthAuthenticator
-import cord.eoeo.momentwo.data.authentication.AuthInterceptor
+import cord.eoeo.momentwo.core.network.MomentwoApi
+import cord.eoeo.momentwo.core.network.AuthAuthenticator
+import cord.eoeo.momentwo.core.network.AuthInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/core/network/src/main/java/cord/eoeo/momentwo/core/network/AuthAuthenticator.kt
+++ b/core/network/src/main/java/cord/eoeo/momentwo/core/network/AuthAuthenticator.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.data.authentication
+package cord.eoeo.momentwo.core.network
 
 import android.util.Log
 import cord.eoeo.momentwo.core.datastore.PreferenceRepository

--- a/core/network/src/main/java/cord/eoeo/momentwo/core/network/AuthInterceptor.kt
+++ b/core/network/src/main/java/cord/eoeo/momentwo/core/network/AuthInterceptor.kt
@@ -1,4 +1,4 @@
-package cord.eoeo.momentwo.data.authentication
+package cord.eoeo.momentwo.core.network
 
 import cord.eoeo.momentwo.core.datastore.PreferenceRepository
 import kotlinx.coroutines.runBlocking

--- a/core/network/src/main/java/cord/eoeo/momentwo/core/network/AuthModule.kt
+++ b/core/network/src/main/java/cord/eoeo/momentwo/core/network/AuthModule.kt
@@ -1,8 +1,8 @@
-package cord.eoeo.momentwo.di
+package cord.eoeo.momentwo.core.network
 
 import cord.eoeo.momentwo.core.datastore.PreferenceRepository
-import cord.eoeo.momentwo.data.authentication.AuthAuthenticator
-import cord.eoeo.momentwo.data.authentication.AuthInterceptor
+import cord.eoeo.momentwo.core.network.AuthAuthenticator
+import cord.eoeo.momentwo.core.network.AuthInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/core/network/src/main/java/cord/eoeo/momentwo/core/network/MomentwoApi.kt
+++ b/core/network/src/main/java/cord/eoeo/momentwo/core/network/MomentwoApi.kt
@@ -1,6 +1,6 @@
-package cord.eoeo.momentwo.data
+package cord.eoeo.momentwo.core.network
 
-import cord.eoeo.momentwo.BuildConfig
+import cord.eoeo.momentwo.core.network.BuildConfig
 
 object MomentwoApi {
     const val BASE_URL = BuildConfig.BASE_URL

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ retrofit = "2.11.0"
 moshi = "1.15.1"
 okhttp-bom = "4.12.0"
 kotlin-serialization = "1.7.3"
+coroutines = "1.7.3"
 
 # Image / Storage / Paging / Room
 coil = "2.7.0"
@@ -69,6 +70,7 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.r
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
 moshi = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
+coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp-bom" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,4 +21,5 @@ include(":core:model")
 include(":core:common")
 include(":core:ui")
 include(":core:datastore")
+include(":core:network")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:network` 모듈 분리. (스택: `refactor/core-datastore` 위)

> base가 `refactor/core-datastore`인 스택 PR입니다. 하위 PR들이 develop에 병합되면 base를 재지정합니다.

## 변경
- `:core:network` 신설 (`momentwo.android.library` + `momentwo.android.network` + `momentwo.android.hilt`)
- HTTP 인프라 이동: `MomentwoApi`(엔드포인트 상수), `AuthInterceptor`/`AuthAuthenticator`, `ApiModule`, `AuthModule`
- `BASE_URL`을 network의 `BuildConfig`로 이관하고 app의 미사용 BASE_URL 설정(field/helper/import) 제거
- `network → datastore` 의존 (AuthInterceptor가 `PreferenceRepository` 참조)
- version catalog에 `coroutines-core`(1.7.3) 추가 — network의 Auth 인터셉터가 coroutines를 직접 사용하는데 전이로 안 들어오기 때문

## 스코프 결정
- DTO(`data/model`, 59개 파일 참조)·per-domain Service·DataSource는 **매핑과 한 덩어리**라 `:core:data` PR에서 함께 이동한다. 본 PR의 network는 순수 HTTP 인프라만 포함(계획서 §6의 "DTO→network"와는 다르게, 응집도 우선).

## 검증
- `./gradlew :core:network:assembleDebug :app:assembleDebug` ✅ (Hilt 그래프 포함)

Closes #113
Part of #108