### PR TITLE
refactor: :core:navigation 모듈 분리

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,6 +48,7 @@ dependencies {
     implementation(project(":core:database"))
     implementation(project(":core:data"))
     implementation(project(":core:domain"))
+    implementation(project(":core:navigation"))
 
     implementation(libs.core.ktx)
     implementation(libs.activity.compose)

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavGraph.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavGraph.kt
@@ -1,4 +1,5 @@
 package cord.eoeo.momentwo.ui
+import cord.eoeo.momentwo.core.navigation.MomentwoDestination
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier

--- a/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/MomentwoNavigation.kt
@@ -2,53 +2,7 @@ package cord.eoeo.momentwo.ui
 
 import androidx.navigation.NavHostController
 import cord.eoeo.momentwo.core.model.AlbumItem
-import kotlinx.serialization.Serializable
-
-sealed interface MomentwoDestination {
-    @Serializable
-    data object Login : MomentwoDestination
-
-    @Serializable
-    data object SignUp : MomentwoDestination
-
-    @Serializable
-    data object Album : MomentwoDestination
-
-    @Serializable
-    data class AlbumDetail(
-        val id: Int,
-        val title: String,
-        val subTitle: String,
-        val imageUrl: String,
-    ) : MomentwoDestination
-
-    @Serializable
-    data class PhotoList(
-        val albumId: Int,
-        val subAlbumId: Int,
-        val albumTitle: String,
-        val subAlbumTitle: String,
-    ) : MomentwoDestination
-
-    @Serializable
-    data class PhotoDetail(
-        val albumId: Int,
-        val photoId: Int,
-        val photoUrl: String,
-        val isLiked: Boolean,
-    ) : MomentwoDestination
-
-    @Serializable
-    data object CreateAlbum : MomentwoDestination
-
-    @Serializable
-    data class Profile(
-        val nickname: String?,
-    ) : MomentwoDestination
-
-    @Serializable
-    data object Friend : MomentwoDestination
-}
+import cord.eoeo.momentwo.core.navigation.MomentwoDestination
 
 class MomentwoNavigationActions(
     navController: NavHostController,

--- a/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/albumdetail/AlbumDetailViewModel.kt
@@ -10,7 +10,7 @@ import cord.eoeo.momentwo.core.data.album.AlbumRepository
 import cord.eoeo.momentwo.core.domain.friend.GetFriendListUseCase
 import cord.eoeo.momentwo.core.data.subalbum.SubAlbumRepository
 import cord.eoeo.momentwo.core.common.BaseViewModel
-import cord.eoeo.momentwo.ui.MomentwoDestination
+import cord.eoeo.momentwo.core.navigation.MomentwoDestination
 import cord.eoeo.momentwo.core.model.AlbumItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailViewModel.kt
@@ -10,7 +10,7 @@ import cord.eoeo.momentwo.core.data.like.LikeRepository
 import cord.eoeo.momentwo.core.domain.photo.DownloadPhotoUseCase
 import cord.eoeo.momentwo.core.domain.photo.UpdateIsLikedUseCase
 import cord.eoeo.momentwo.core.common.BaseViewModel
-import cord.eoeo.momentwo.ui.MomentwoDestination
+import cord.eoeo.momentwo.core.navigation.MomentwoDestination
 import cord.eoeo.momentwo.core.model.DescriptionItem
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch

--- a/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photolist/PhotoListViewModel.kt
@@ -7,7 +7,7 @@ import androidx.navigation.toRoute
 import cord.eoeo.momentwo.core.data.photo.PhotoRepository
 import cord.eoeo.momentwo.core.domain.subalbum.ChangeSubAlbumTitleUseCase
 import cord.eoeo.momentwo.core.common.BaseViewModel
-import cord.eoeo.momentwo.ui.MomentwoDestination
+import cord.eoeo.momentwo.core.navigation.MomentwoDestination
 import cord.eoeo.momentwo.ui.photolist.PhotoListContract.Effect.ShowSnackbar
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch

--- a/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/profile/ProfileViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.navigation.toRoute
 import cord.eoeo.momentwo.core.data.profile.ProfileRepository
 import cord.eoeo.momentwo.core.common.BaseViewModel
-import cord.eoeo.momentwo.ui.MomentwoDestination
+import cord.eoeo.momentwo.core.navigation.MomentwoDestination
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    alias(libs.plugins.momentwo.android.library)
+    alias(libs.plugins.kotlinSerialization)
+}
+
+android {
+    namespace = "cord.eoeo.momentwo.core.navigation"
+}
+
+dependencies {
+    implementation(libs.kotlin.serialization)
+}

--- a/core/navigation/src/main/java/cord/eoeo/momentwo/core/navigation/MomentwoDestination.kt
+++ b/core/navigation/src/main/java/cord/eoeo/momentwo/core/navigation/MomentwoDestination.kt
@@ -1,0 +1,49 @@
+package cord.eoeo.momentwo.core.navigation
+
+import kotlinx.serialization.Serializable
+
+sealed interface MomentwoDestination {
+    @Serializable
+    data object Login : MomentwoDestination
+
+    @Serializable
+    data object SignUp : MomentwoDestination
+
+    @Serializable
+    data object Album : MomentwoDestination
+
+    @Serializable
+    data class AlbumDetail(
+        val id: Int,
+        val title: String,
+        val subTitle: String,
+        val imageUrl: String,
+    ) : MomentwoDestination
+
+    @Serializable
+    data class PhotoList(
+        val albumId: Int,
+        val subAlbumId: Int,
+        val albumTitle: String,
+        val subAlbumTitle: String,
+    ) : MomentwoDestination
+
+    @Serializable
+    data class PhotoDetail(
+        val albumId: Int,
+        val photoId: Int,
+        val photoUrl: String,
+        val isLiked: Boolean,
+    ) : MomentwoDestination
+
+    @Serializable
+    data object CreateAlbum : MomentwoDestination
+
+    @Serializable
+    data class Profile(
+        val nickname: String?,
+    ) : MomentwoDestination
+
+    @Serializable
+    data object Friend : MomentwoDestination
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,4 +25,5 @@ include(":core:network")
 include(":core:database")
 include(":core:data")
 include(":core:domain")
+include(":core:navigation")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:navigation` 모듈 분리. (스택: `refactor/core-domain` 위)

> base가 `refactor/core-domain`인 스택 PR입니다. 하위 PR들이 develop에 병합되면 base를 재지정합니다.

## 변경
- `:core:navigation` 신설 (`momentwo.android.library` + kotlin-serialization), 의존: serialization 런타임
- **Route 키** `MomentwoDestination`(sealed interface, `@Serializable`) → `core.navigation` 이동
- **NavHost 본체**(`MomentwoNavGraph`)와 `MomentwoNavigationActions`는 `:app` 잔존
- 같은 파일에 있던 `MomentwoDestination`/`MomentwoNavigationActions` 분리, 참조 갱신(ViewModel 4 + same-package NavGraph/Actions)

## 설계
- 이 코드베이스는 type-safe navigation(@Serializable data class)이라 커스텀 `NavType`·`FeatureNavGraphBuilder`는 없음 → Route 키만 분리
- `MomentwoDestination`은 primitive만 사용해 `core.model` 비의존
- Phase 2에서 화면별 Route를 `:feature:*:api`로 재분리 예정(현재는 core.navigation에 통합)

## 검증
- `./gradlew :core:navigation:assembleDebug :app:assembleDebug` ✅

Closes #120
Part of #108