### PR TITLE
refactor: :core:testing 모듈 분리

### DIFF
--- a/core/testing/build.gradle.kts
+++ b/core/testing/build.gradle.kts
@@ -1,0 +1,12 @@
+plugins {
+    alias(libs.plugins.momentwo.android.library)
+}
+
+android {
+    namespace = "cord.eoeo.momentwo.core.testing"
+}
+
+dependencies {
+    api(libs.junit)
+    api(libs.coroutines.test)
+}

--- a/core/testing/src/main/java/cord/eoeo/momentwo/core/testing/MainDispatcherRule.kt
+++ b/core/testing/src/main/java/cord/eoeo/momentwo/core/testing/MainDispatcherRule.kt
@@ -1,0 +1,28 @@
+package cord.eoeo.momentwo.core.testing
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+/**
+ * `Dispatchers.Main`을 테스트용 [TestDispatcher]로 교체하는 JUnit Rule.
+ *
+ * `viewModelScope` 등 Main 디스패처에 의존하는 코루틴을 단위 테스트에서 제어하기 위해 사용한다.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainDispatcherRule(
+    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(),
+) : TestWatcher() {
+    override fun starting(description: Description) {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description) {
+        Dispatchers.resetMain()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 moshi-converter = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
 moshi = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshi" }
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
+coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 okhttp-bom = { group = "com.squareup.okhttp3", name = "okhttp-bom", version.ref = "okhttp-bom" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp" }
 okhttp-logging-interceptor = { group = "com.squareup.okhttp3", name = "logging-interceptor" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,4 +26,5 @@ include(":core:database")
 include(":core:data")
 include(":core:domain")
 include(":core:navigation")
+include(":core:testing")
  


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:testing` 모듈 (스택: `refactor/core-navigation` 위, Phase 1 마지막 core 모듈)

> base가 `refactor/core-navigation`인 스택 PR입니다. 하위 PR들이 develop에 병합되면 base를 재지정합니다.

## 변경
- `:core:testing` 신설 (`momentwo.android.library`), `junit`/`coroutines-test`를 `api`로 노출
- `MainDispatcherRule` 추가 — `Dispatchers.Main`을 `TestDispatcher`로 교체하는 JUnit Rule (viewModelScope 등 코루틴 테스트용)
- version catalog에 `kotlinx-coroutines-test`(1.7.3) 추가

## 설계
- 현재 프로젝트에 이동할 테스트 더블/유틸이 없음(`ExampleUnitTest`/`ExampleInstrumentedTest` 보일러플레이트뿐) → 표준 유틸 `MainDispatcherRule`만 두는 **최소 구성**으로 시작. Fake 등은 실제 테스트 작성 시 확충.

## 검증
- `./gradlew :core:testing:assembleDebug` ✅

Closes #121
Part of #108