### PR TITLE
refactor: DataSource Dispatcher 를 @IoDispatcher 주입으로 전환

### DIFF
--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/album/remote/AlbumRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/album/remote/AlbumRemoteDataSource.kt
@@ -10,12 +10,11 @@ import cord.eoeo.momentwo.core.data.model.EditAlbumTitle
 import cord.eoeo.momentwo.core.data.model.PresignedRequest
 import cord.eoeo.momentwo.core.data.model.PresignedUrl
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class AlbumRemoteDataSource(
     private val albumService: AlbumService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : AlbumDataSource {
     override suspend fun requestCreateAlbum(createAlbumInfo: CreateAlbumInfo): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/comment/remote/CommentRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/comment/remote/CommentRemoteDataSource.kt
@@ -5,12 +5,11 @@ import cord.eoeo.momentwo.core.data.model.CommentPage
 import cord.eoeo.momentwo.core.data.model.CreateComment
 import cord.eoeo.momentwo.core.data.model.EditComment
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class CommentRemoteDataSource(
     private val commentService: CommentService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : CommentDataSource {
     override suspend fun createComment(createComment: CreateComment): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/description/remote/DescriptionRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/description/remote/DescriptionRemoteDataSource.kt
@@ -5,12 +5,11 @@ import cord.eoeo.momentwo.core.data.model.CreateDescription
 import cord.eoeo.momentwo.core.data.model.Description
 import cord.eoeo.momentwo.core.data.model.EditDescription
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class DescriptionRemoteDataSource(
     private val descriptionService: DescriptionService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : DescriptionDataSource {
     override suspend fun createDescription(createDescription: CreateDescription): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/AlbumModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/AlbumModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import android.content.Context
 import cord.eoeo.momentwo.core.data.album.AlbumDataSource
@@ -24,7 +26,10 @@ object AlbumModule {
 
     @Provides
     @Singleton
-    fun provideAlbumRemoteDataSource(albumService: AlbumService): AlbumDataSource = AlbumRemoteDataSource(albumService)
+    fun provideAlbumRemoteDataSource(
+        albumService: AlbumService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): AlbumDataSource = AlbumRemoteDataSource(albumService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/CommentModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/CommentModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.comment.CommentDataSource
 import cord.eoeo.momentwo.core.data.comment.CommentRepository
@@ -22,8 +24,11 @@ object CommentModule {
 
     @Provides
     @Singleton
-    fun provideCommentRemoteDataSource(commentService: CommentService): CommentDataSource =
-        CommentRemoteDataSource(commentService)
+    fun provideCommentRemoteDataSource(
+        commentService: CommentService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): CommentDataSource =
+        CommentRemoteDataSource(commentService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/DescriptionModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/DescriptionModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.description.DescriptionDataSource
 import cord.eoeo.momentwo.core.data.description.DescriptionRepository
@@ -22,8 +24,11 @@ object DescriptionModule {
 
     @Provides
     @Singleton
-    fun provideDescriptionRemoteDataSource(descriptionService: DescriptionService): DescriptionDataSource =
-        DescriptionRemoteDataSource(descriptionService)
+    fun provideDescriptionRemoteDataSource(
+        descriptionService: DescriptionService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): DescriptionDataSource =
+        DescriptionRemoteDataSource(descriptionService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/FriendModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/FriendModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.database.MomentwoDatabase
 import cord.eoeo.momentwo.core.data.friend.FriendDataSource
@@ -35,17 +37,21 @@ object FriendModule {
     @Provides
     @Singleton
     @QualifierModule.RemoteDataSource
-    fun provideFriendRemoteDataSource(friendService: FriendService): FriendDataSource.Remote =
-        FriendRemoteDataSource(friendService)
+    fun provideFriendRemoteDataSource(
+        friendService: FriendService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): FriendDataSource.Remote =
+        FriendRemoteDataSource(friendService, dispatcher)
 
     @Provides
     @Singleton
     @QualifierModule.LocalDataSource
     fun provideFriendLocalDataSource(
         friendDao: FriendDao,
-        friendRemoteKeyDao: FriendRemoteKeyDao
+        friendRemoteKeyDao: FriendRemoteKeyDao,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
     ): FriendDataSource.Local =
-        FriendLocalDataSource(friendDao, friendRemoteKeyDao)
+        FriendLocalDataSource(friendDao, friendRemoteKeyDao, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/LikeModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/LikeModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.like.LikeDataSource
 import cord.eoeo.momentwo.core.data.like.LikeRepository
@@ -22,8 +24,11 @@ object LikeModule {
 
     @Provides
     @Singleton
-    fun provideLikeRemoteDataSource(likeService: LikeService): LikeDataSource =
-        LikeRemoteDataSource(likeService)
+    fun provideLikeRemoteDataSource(
+        likeService: LikeService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): LikeDataSource =
+        LikeRemoteDataSource(likeService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/LoginModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/LoginModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.login.LoginDataSource
 import cord.eoeo.momentwo.core.data.login.LoginRepositoryImpl
@@ -22,7 +24,10 @@ object LoginModule {
 
     @Provides
     @Singleton
-    fun provideLoginRemoteDataSource(loginService: LoginService): LoginDataSource = LoginRemoteDataSource(loginService)
+    fun provideLoginRemoteDataSource(
+        loginService: LoginService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): LoginDataSource = LoginRemoteDataSource(loginService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/MemberModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/MemberModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.member.MemberDataSource
 import cord.eoeo.momentwo.core.data.member.MemberRepository
@@ -21,7 +23,10 @@ object MemberModule {
 
     @Provides
     @Singleton
-    fun provideMemberRemoteDataSource(memberService: MemberService): MemberDataSource = MemberRemoteDataSource(memberService)
+    fun provideMemberRemoteDataSource(
+        memberService: MemberService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): MemberDataSource = MemberRemoteDataSource(memberService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/PhotoModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/PhotoModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import android.content.Context
 import cord.eoeo.momentwo.core.database.MomentwoDatabase
@@ -38,8 +40,11 @@ object PhotoModule {
     @Provides
     @Singleton
     @QualifierModule.RemoteDataSource
-    fun providePhotoRemoteDataSource(photoService: PhotoService): PhotoDataSource.Remote =
-        PhotoRemoteDataSource(photoService)
+    fun providePhotoRemoteDataSource(
+        photoService: PhotoService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): PhotoDataSource.Remote =
+        PhotoRemoteDataSource(photoService, dispatcher)
 
     @Provides
     @Singleton
@@ -47,7 +52,8 @@ object PhotoModule {
     fun providePhotoLocalDataSource(
         photoDao: PhotoDao,
         photoRemoteKeyDao: PhotoRemoteKeyDao,
-    ): PhotoDataSource.Local = PhotoLocalDataSource(photoDao, photoRemoteKeyDao)
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): PhotoDataSource.Local = PhotoLocalDataSource(photoDao, photoRemoteKeyDao, dispatcher)
 
     @Provides
     @Singleton
@@ -64,11 +70,13 @@ object PhotoModule {
         presignedRemoteDataSource: PresignedDataSource,
         photoRemoteMediator: PhotoRemoteMediator,
         @ApplicationContext applicationContext: Context,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
     ): PhotoRepository = PhotoRepositoryImpl(
         photoRemoteDataSource,
         photoLocalDataSource,
         presignedRemoteDataSource,
         photoRemoteMediator,
         applicationContext,
+        dispatcher,
     )
 }

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/PresignedModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/PresignedModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.presigned.PresignedDataSource
 import cord.eoeo.momentwo.core.data.presigned.remote.PresignedRemoteDataSource
@@ -19,6 +21,9 @@ object PresignedModule {
 
     @Provides
     @Singleton
-    fun providePresignedRemoteDataSource(presignedService: PresignedService): PresignedDataSource =
-        PresignedRemoteDataSource(presignedService)
+    fun providePresignedRemoteDataSource(
+        presignedService: PresignedService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): PresignedDataSource =
+        PresignedRemoteDataSource(presignedService, dispatcher)
 }

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/ProfileModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/ProfileModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.database.MomentwoDatabase
 import cord.eoeo.momentwo.core.data.profile.ProfileDataSource
@@ -30,12 +32,18 @@ object ProfileModule {
     @Provides
     @Singleton
     @QualifierModule.LocalDataSource
-    fun provideProfileLocalDataSource(profileDao: ProfileDao): ProfileDataSource.Local = ProfileLocalDataSource(profileDao)
+    fun provideProfileLocalDataSource(
+        profileDao: ProfileDao,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): ProfileDataSource.Local = ProfileLocalDataSource(profileDao, dispatcher)
 
     @Provides
     @Singleton
     @QualifierModule.RemoteDataSource
-    fun provideProfileRemoteDataSource(profileService: ProfileService): ProfileDataSource.Remote = ProfileRemoteDataSource(profileService)
+    fun provideProfileRemoteDataSource(
+        profileService: ProfileService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): ProfileDataSource.Remote = ProfileRemoteDataSource(profileService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/SignUpModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/SignUpModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.signup.remote.SignUpService
 import cord.eoeo.momentwo.core.data.signup.SignUpDataSource
@@ -22,8 +24,11 @@ object SignUpModule {
 
     @Provides
     @Singleton
-    fun provideSignUpRemoteDataSource(signUpService: SignUpService): SignUpDataSource =
-        SignUpRemoteDataSource(signUpService)
+    fun provideSignUpRemoteDataSource(
+        signUpService: SignUpService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): SignUpDataSource =
+        SignUpRemoteDataSource(signUpService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/SubAlbumModule.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/di/SubAlbumModule.kt
@@ -1,4 +1,6 @@
 package cord.eoeo.momentwo.core.data.di
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
+import kotlinx.coroutines.CoroutineDispatcher
 
 import cord.eoeo.momentwo.core.data.subalbum.SubAlbumDataSource
 import cord.eoeo.momentwo.core.data.subalbum.SubAlbumRepositoryImpl
@@ -21,8 +23,11 @@ object SubAlbumModule {
 
     @Provides
     @Singleton
-    fun provideSubAlbumRemoteDataSource(subAlbumService: SubAlbumService): SubAlbumDataSource =
-        SubAlbumRemoteDataSource(subAlbumService)
+    fun provideSubAlbumRemoteDataSource(
+        subAlbumService: SubAlbumService,
+        @IoDispatcher dispatcher: CoroutineDispatcher,
+    ): SubAlbumDataSource =
+        SubAlbumRemoteDataSource(subAlbumService, dispatcher)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/friend/local/FriendLocalDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/friend/local/FriendLocalDataSource.kt
@@ -7,13 +7,12 @@ import cord.eoeo.momentwo.core.database.FriendRemoteKeyDao
 import cord.eoeo.momentwo.core.database.FriendEntity
 import cord.eoeo.momentwo.core.database.FriendRemoteKeyEntity
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class FriendLocalDataSource(
     private val friendDao: FriendDao,
     private val friendRemoteKeyDao: FriendRemoteKeyDao,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher
 ) : FriendDataSource.Local {
     override fun getPhotoPagingSource(): PagingSource<Int, FriendEntity> =
         friendDao.getFriendPagingSource()

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/friend/remote/FriendRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/friend/remote/FriendRemoteDataSource.kt
@@ -7,12 +7,11 @@ import cord.eoeo.momentwo.core.data.model.ReceivedFriendRequestList
 import cord.eoeo.momentwo.core.data.model.SearchUser
 import cord.eoeo.momentwo.core.data.model.SentFriendRequestList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class FriendRemoteDataSource(
     private val friendService: FriendService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : FriendDataSource.Remote {
     override suspend fun sendFriendRequest(nickname: String): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/like/remote/LikeRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/like/remote/LikeRemoteDataSource.kt
@@ -4,12 +4,11 @@ import cord.eoeo.momentwo.core.data.like.LikeDataSource
 import cord.eoeo.momentwo.core.data.model.LikeCount
 import cord.eoeo.momentwo.core.data.model.LikeRequest
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class LikeRemoteDataSource(
     private val likeService: LikeService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : LikeDataSource {
     override suspend fun requestDoLike(likeRequest: LikeRequest): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/login/remote/LoginRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/login/remote/LoginRemoteDataSource.kt
@@ -4,13 +4,12 @@ import cord.eoeo.momentwo.core.data.login.LoginDataSource
 import cord.eoeo.momentwo.core.data.model.LoginRequest
 import cord.eoeo.momentwo.core.data.model.UserProfile
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import retrofit2.Response
 
 class LoginRemoteDataSource(
     private val loginService: LoginService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : LoginDataSource {
     override suspend fun requestLogin(loginData: LoginRequest): Response<UserProfile> =
         withContext(dispatcher) {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/member/remote/MemberRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/member/remote/MemberRemoteDataSource.kt
@@ -6,12 +6,11 @@ import cord.eoeo.momentwo.core.data.model.EditMembers
 import cord.eoeo.momentwo.core.data.model.InviteMembers
 import cord.eoeo.momentwo.core.data.model.MemberList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class MemberRemoteDataSource(
     private val memberService: MemberService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : MemberDataSource {
     override suspend fun exitFromAlbum(albumId: Int): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/photo/PhotoRepositoryImpl.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/photo/PhotoRepositoryImpl.kt
@@ -19,8 +19,9 @@ import cord.eoeo.momentwo.core.data.model.UploadPhoto
 import cord.eoeo.momentwo.core.data.model.UriRequestBody
 import cord.eoeo.momentwo.core.data.presigned.PresignedDataSource
 import cord.eoeo.momentwo.core.data.photo.PhotoRepository
+import cord.eoeo.momentwo.core.common.dispatcher.IoDispatcher
 import cord.eoeo.momentwo.core.model.PhotoItem
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
@@ -31,6 +32,7 @@ class PhotoRepositoryImpl(
     private val presignedRemoteDataSource: PresignedDataSource,
     private val photoRemoteMediator: PhotoRemoteMediator,
     private val applicationContext: Context,
+    @IoDispatcher private val dispatcher: CoroutineDispatcher,
 ) : PhotoRepository {
     private val imageLoader = applicationContext.imageLoader
     private val contentResolver = applicationContext.contentResolver
@@ -136,7 +138,7 @@ class PhotoRepositoryImpl(
     }
 
     private suspend fun loadBitmapFromUrl(imageUrl: String): Bitmap? =
-        withContext(Dispatchers.IO) {
+        withContext(dispatcher) {
             (
                 (
                     (

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/photo/local/PhotoLocalDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/photo/local/PhotoLocalDataSource.kt
@@ -8,14 +8,13 @@ import cord.eoeo.momentwo.core.database.PhotoRemoteKeyDao
 import cord.eoeo.momentwo.core.database.PhotoEntity
 import cord.eoeo.momentwo.core.database.PhotoRemoteKeyEntity
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.OutputStream
 
 class PhotoLocalDataSource(
     private val photoDao: PhotoDao,
     private val photoRemoteKeyDao: PhotoRemoteKeyDao,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher
 ) : PhotoDataSource.Local {
     override fun getPhotoPagingSource(albumId: Int, subAlbumId: Int): PagingSource<Int, PhotoEntity> =
         photoDao.getPhotoPagingSource(albumId, subAlbumId)

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/photo/remote/PhotoRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/photo/remote/PhotoRemoteDataSource.kt
@@ -7,12 +7,11 @@ import cord.eoeo.momentwo.core.data.model.PresignedUrl
 import cord.eoeo.momentwo.core.data.model.UploadPhoto
 import cord.eoeo.momentwo.core.data.photo.PhotoDataSource
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class PhotoRemoteDataSource(
     private val photoService: PhotoService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : PhotoDataSource.Remote {
     override suspend fun getPhotoPage(
         albumId: Int,

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/presigned/remote/PresignedRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/presigned/remote/PresignedRemoteDataSource.kt
@@ -2,13 +2,12 @@ package cord.eoeo.momentwo.core.data.presigned.remote
 
 import cord.eoeo.momentwo.core.data.presigned.PresignedDataSource
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import okhttp3.RequestBody
 
 class PresignedRemoteDataSource(
     private val presignedService: PresignedService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher
 ): PresignedDataSource {
     override suspend fun uploadPhoto(presignedUrl: String, image: RequestBody): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/profile/local/ProfileLocalDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/profile/local/ProfileLocalDataSource.kt
@@ -4,12 +4,11 @@ import cord.eoeo.momentwo.core.data.profile.ProfileDataSource
 import cord.eoeo.momentwo.core.database.ProfileDao
 import cord.eoeo.momentwo.core.database.ProfileEntity
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class ProfileLocalDataSource(
     private val profileDao: ProfileDao,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : ProfileDataSource.Local {
     override suspend fun storeProfile(profile: ProfileEntity): Result<Unit> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/profile/remote/ProfileRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/profile/remote/ProfileRemoteDataSource.kt
@@ -3,12 +3,11 @@ package cord.eoeo.momentwo.core.data.profile.remote
 import cord.eoeo.momentwo.core.data.model.UserProfile
 import cord.eoeo.momentwo.core.data.profile.ProfileDataSource
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class ProfileRemoteDataSource(
     private val profileService: ProfileService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : ProfileDataSource.Remote {
     override suspend fun getProfile(nickname: String): Result<UserProfile> =
         runCatching {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/signup/remote/SignUpRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/signup/remote/SignUpRemoteDataSource.kt
@@ -3,12 +3,11 @@ package cord.eoeo.momentwo.core.data.signup.remote
 import cord.eoeo.momentwo.core.data.model.User
 import cord.eoeo.momentwo.core.data.signup.SignUpDataSource
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class SignUpRemoteDataSource(
     private val signUpService: SignUpService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatcher: CoroutineDispatcher
 ) : SignUpDataSource {
     override suspend fun requestSignUp(user: User): Result<Unit> = runCatching {
         withContext(dispatcher) {

--- a/core/data/src/main/java/cord/eoeo/momentwo/core/data/subalbum/remote/SubAlbumRemoteDataSource.kt
+++ b/core/data/src/main/java/cord/eoeo/momentwo/core/data/subalbum/remote/SubAlbumRemoteDataSource.kt
@@ -5,12 +5,11 @@ import cord.eoeo.momentwo.core.data.model.EditSubAlbumInfo
 import cord.eoeo.momentwo.core.data.model.SubAlbumList
 import cord.eoeo.momentwo.core.data.subalbum.SubAlbumDataSource
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
 class SubAlbumRemoteDataSource(
     private val subAlbumService: SubAlbumService,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatcher: CoroutineDispatcher,
 ) : SubAlbumDataSource {
     override suspend fun requestCreateSubAlbum(createSubAlbumInfo: CreateSubAlbumInfo): Result<Unit> =
         runCatching {


### PR DESCRIPTION
멀티모듈 마이그레이션 Phase 1 — `:core:common`에서 미뤄 둔 **Dispatcher 주입 전환** 후속. (스택: `refactor/core-testing` 위)

> base가 `refactor/core-testing`인 스택 최상단 PR입니다. 하위 PR들이 develop에 병합되면 base를 재지정합니다.

## 변경
- 15개 DataSource(`*RemoteDataSource`/`*LocalDataSource`)와 `PhotoRepositoryImpl`의 하드코딩된 `Dispatchers.IO`(생성자 기본값 및 인라인 `withContext(Dispatchers.IO)`) 제거
- `:core:common`의 `@IoDispatcher`(DispatchersModule 제공)로 Hilt 주입받도록 전환
- 각 도메인 di 모듈(`core.data.di`)의 `@Provides`가 `@IoDispatcher dispatcher: CoroutineDispatcher`를 받아 생성자에 전달

## 배경
- `:core:common` PR(#131)에서 `@IoDispatcher`/`DispatchersModule` 인프라만 두고, 실제 주입 전환은 대상 파일이 `:core:data`로 이동한 뒤 별도 PR로 하기로 했던 작업(적극 리팩터링)의 마무리
- 규모(~16 파일 + di @Provides)가 커서 `:core:data` 이동 PR과 분리

## 검증
- `./gradlew :core:data:assembleDebug :app:assembleDebug` ✅ (Hilt 그래프 @IoDispatcher 주입 확인)

Part of #108