### PR TITLE
fix: Scaffold content padding lint 정리

### DIFF
--- a/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/photodetail/PhotoDetailScreen.kt
@@ -56,6 +56,8 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.onEach
 
+// 몰입형 전체화면 사진 뷰어 — 바(AnimatedVisibility)가 오버레이되며 사진은 edge-to-edge full-bleed 유지
+@Suppress("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun PhotoDetailScreen(
     coroutineScope: CoroutineScope,

--- a/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpScreen.kt
+++ b/app/src/main/java/cord/eoeo/momentwo/ui/signup/SignUpScreen.kt
@@ -3,6 +3,7 @@ package cord.eoeo.momentwo.ui.signup
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -87,48 +88,50 @@ fun SignUpScreen(
         snackbarHost = { SnackbarHost(hostState = snackbarHostState()) },
         modifier = Modifier.fillMaxWidth()
     ) { paddingValues ->
-        HorizontalPager(
-            state = pagerState(),
-            userScrollEnabled = false,
-            modifier = Modifier.fillMaxWidth(),
-            beyondViewportPageCount = 1,
-        ) { page ->
-            if (page == 0) {
-                FirstSignUpPage(
-                    email = { uiState().email },
-                    password = { uiState().password },
-                    passwordCheck = { uiState().passwordCheck },
-                ) { event -> onEvent(event) }
-            } else {
-                SecondSignUpPage(
-                    nickname = { uiState().nickname },
-                    name = { uiState().name },
-                    birthday = { uiState().birthday },
-                    phone = { uiState().phone },
-                ) { event -> onEvent(event) }
-            }
-        }
-
-        Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(0.dp, 0.dp, 32.dp, 32.dp),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.Bottom,
-        ) {
-            Button(
-                onClick = {
-                    if (pagerState().currentPage == 0) {
-                        onEvent(SignUpContract.Event.OnNextClicked)
-                    } else {
-                        onEvent(SignUpContract.Event.OnAcceptClicked)
-                    }
-                },
-            ) {
-                if (pagerState().currentPage == 0) {
-                    Text(text = "다음")
+        Box(modifier = Modifier.padding(paddingValues)) {
+            HorizontalPager(
+                state = pagerState(),
+                userScrollEnabled = false,
+                modifier = Modifier.fillMaxWidth(),
+                beyondViewportPageCount = 1,
+            ) { page ->
+                if (page == 0) {
+                    FirstSignUpPage(
+                        email = { uiState().email },
+                        password = { uiState().password },
+                        passwordCheck = { uiState().passwordCheck },
+                    ) { event -> onEvent(event) }
                 } else {
-                    Text(text = "확인")
+                    SecondSignUpPage(
+                        nickname = { uiState().nickname },
+                        name = { uiState().name },
+                        birthday = { uiState().birthday },
+                        phone = { uiState().phone },
+                    ) { event -> onEvent(event) }
+                }
+            }
+
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(0.dp, 0.dp, 32.dp, 32.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                Button(
+                    onClick = {
+                        if (pagerState().currentPage == 0) {
+                            onEvent(SignUpContract.Event.OnNextClicked)
+                        } else {
+                            onEvent(SignUpContract.Event.OnAcceptClicked)
+                        }
+                    },
+                ) {
+                    if (pagerState().currentPage == 0) {
+                        Text(text = "다음")
+                    } else {
+                        Text(text = "확인")
+                    }
                 }
             }
         }


### PR DESCRIPTION
`:app:lintDebug`를 막던 기존 lint 에러 2건(`UnusedMaterial3ScaffoldPaddingParameter`)을 정리합니다. Phase 1 진행 중에는 이 debt 때문에 게이트를 `assembleDebug`로만 삼아 왔는데, 이제 `lintDebug`도 green으로 만듭니다.

## 변경
- **SignUpScreen**: Scaffold content를 `Box(Modifier.padding(paddingValues))`로 감싸 시스템 바 인셋 존중 (Friend/Profile 등 다른 5개 화면과 동일 패턴). 앱이 edge-to-edge라 폼이 상태 바 아래로 인셋됨.
- **PhotoDetailScreen**: 몰입형 전체화면 사진 뷰어(바가 `AnimatedVisibility`로 오버레이 토글)라 edge-to-edge full-bleed가 의도. `paddingValues` 적용 시 바 토글마다 사진이 리사이즈되어 부적절하므로 `@Suppress` + 사유 주석으로 억제.

## 검증
- `./gradlew :app:lintDebug` — **에러 0** (기존 2건 해소)
- `./gradlew :app:assembleDebug` ✅

Part of #108